### PR TITLE
Code generation only prints with `owlkettleDebug` defined.

### DIFF
--- a/owlkettle/guidsl.nim
+++ b/owlkettle/guidsl.nim
@@ -258,4 +258,5 @@ macro gui*(tree: untyped): untyped =
   let gui = tree.parse_gui()
   result = new_nim_node(nnkStmtListExpr)
   gui.gen(result, nil)
-  echo result.repr
+  when defined owlkettle_debug:
+    echo result.repr

--- a/owlkettle/widgetdef.nim
+++ b/owlkettle/widgetdef.nim
@@ -531,9 +531,11 @@ proc gen(widget: WidgetDef): NimNode =
 macro renderable*(name, body: untyped): untyped =
   let widget = parse_widget_def(WidgetRenderable, name, body)
   result = widget.gen()
-  echo result.repr
+  when defined owlkettle_debug:
+    echo result.repr
 
 macro viewable*(name, body: untyped): untyped =
   let widget = parse_widget_def(WidgetViewable, name, body)
   result = widget.gen()
-  echo result.repr
+  when defined owlkettle_debug:
+    echo result.repr


### PR DESCRIPTION
This will make it easier to see compiler issues and allow easy debugging if needed.
Closes #5 