### PR TITLE
Fix compilation for nimPreviewSlimSystem

### DIFF
--- a/examples/app_launcher.nim
+++ b/examples/app_launcher.nim
@@ -24,6 +24,8 @@
 
 import owlkettle
 import std/[os, strscans, strutils, algorithm, osproc, sequtils, sugar]
+when defined(nimPreviewSlimSystem):
+  import std/[assertions, syncio]
 
 const appPath = "share" / "applications"
 let applicationPaths = [

--- a/owlkettle/adw.nim
+++ b/owlkettle/adw.nim
@@ -22,6 +22,8 @@
 
 # Create libadwaita apps using owlkettle
 
+when defined(nimPreviewSlimSystem):
+  import std/assertions
 import gtk, widgetdef, widgets, mainloop
 
 {.passl: "-ladwaita-1".}

--- a/owlkettle/dataentries.nim
+++ b/owlkettle/dataentries.nim
@@ -20,7 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import std/[strutils]
+import std/strutils
+when defined(nimPreviewSlimSystem):
+  import std/formatfloat
 import widgets, widgetdef, guidsl
 
 proc isFloat(value: string): bool =

--- a/owlkettle/guidsl.nim
+++ b/owlkettle/guidsl.nim
@@ -23,6 +23,8 @@
 # Domain-specific language for specifying GUI layouts
 
 import std/[macros, strutils, genasts]
+when defined(nimPreviewSlimSystem):
+  import std/assertions
 import common, widgetdef
 
 type

--- a/owlkettle/widgetdef.nim
+++ b/owlkettle/widgetdef.nim
@@ -23,6 +23,8 @@
 # Macros used to define new widgets
 
 import std/[macros, strutils, tables]
+when defined(nimPreviewSlimSystem):
+  import std/assertions
 import gtk, common
 
 type

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -23,6 +23,8 @@
 # Default widgets
 
 import std/[unicode, sets, tables, options]
+when defined(nimPreviewSlimSystem):
+  import std/assertions
 import gtk, widgetdef, cairo
 
 when defined(owlkettleDocs):


### PR DESCRIPTION
This flag moves procs out of system such as $ for floats and assert. It will be default in nim v2. Made sure that every example compiles.