### PR TITLE
Feature/#28 add developer tool docs

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -622,7 +622,57 @@ brew(gui(App()))
 Note that there is no `update` or `build` hook defined for the `text` field. If we had defined those, they would need to include sections that call each individual `property` hook like their default implementations would. 
 
 ### **Read Hook**
-# TODO: Write this
+The `read` hook is a custom hook solely used by widgets that are renderables and deal with user input. They may need a hook at times that sends back the current state within a `Widget` whenever the user changes said state through interaction. This hook is then responsible for propagating the changes done by the user from the state of `Widget` to `WidgetState`.
+
+Let's look at a minimal example of the `ColorChooserDialog`:
+
+```nim
+
+import owlkettle
+import owlkettle/[gtk, widgetdef]
+
+# The custom widget
+renderable MyColorChooserDialog of BuiltinDialog:
+  color: tuple[r, g, b, a: float] = (0.0, 0.0, 0.0, 1.0)
+  
+  hooks:
+    beforeBuild: ## Necessary for renderable to instantiate Widget in general
+      state.internalWidget = gtk_color_chooser_dialog_new(
+        widget.valTitle.cstring,
+        nil.GtkWidget
+      )
+  
+  hooks color:
+    read: ## Will execute after userinput was provided, propagates value to to `WidgetState`
+      var color: GdkRgba
+      gtk_color_chooser_get_rgba(state.internalWidget, color.addr)
+      echo "ReadHook - old state color: ", state.color.repr
+      state.color = (color.r.float, color.g.float, color.b.float, color.a.float)
+      echo "ReadHook - new state color: ", state.color.repr
+
+## The App
+viewable App:
+  discard
+
+method view(app: AppState): Widget =
+  result = gui:
+    Window:
+      HeaderBar {.addTitlebar.}:
+        Button {.addLeft.}:
+          text = "Open"
+          style = {ButtonSuggested}
+          proc clicked() =
+            let (res, state) = app.open: gui:
+              MyColorChooserDialog()
+
+brew(gui(App()))
+```
+
+The `read` hook will execute after a color was chosen and confirmed.
+Only then will it update the state with the chosen color. How to extract the data of the user-interaction will depend on the gtk-widget being wrapped.
+
+Note that during the choosing of the color and when updating `WidgetState` via the `read` hook, no `update` hook is being executed.
+
 
 
 ```mermaid

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -241,7 +241,7 @@ The available hooks are:
   - (W) connectEvents   : Only relevant for renderables. Executed every time a callback is supposed to be attached to the underlying GTK widget. It defines how to do so.
   - (W) disconnectEvents: Only relevant for renderables. Executed every time a callback is supposed to be removed from the underlying GTK widget. It defines how to do so.
   - (WF) update         : Executed every time `WidgetState` is updated by `Widget`.
-  - (F) property        : Executed every time the hook-field changed its value in both the update and build phases.
+  - (F) property        : Executed every time the hook-field changed its value during the update or build phases.
   - (F) read            : Used in `Dialog`. Executes every time the state of the underlying GTK-Widget changes.
 
 W: Can act as hook for Widgets
@@ -253,10 +253,10 @@ With the exception of `read`, all hooks also have implicit access to a variable 
 
 Generally the `build`, `property` and `update` hooks are likely to have the highest utility for you. Consult their individual sections for more information.
 
-### Build Hook
+### **Build Hook**
 The `build` hook runs once just before any values are assigned to the `WidgetState`.
 
-#### For Widgets
+#### **For Widgets**
 `build` hooks on widgets should be used when additional logic is necessary that sets multiple fields on `WidgetState` during widget instantiation. Note that such fields should not have assigned default values, as they will be overwritten when default values get applied after the build phase.
 
 Example: A Widget may need to load data from elsewhere, via a file or HTTP request for one field, and a second field must be inferred from a value of the first field.
@@ -348,7 +348,7 @@ Given that the purpose of `beforeBuild` is to handle instantiating renderables a
 
 For more info on the purpose of `beforeBuild` and `afterBuild` hooks, consult their respective sections in this file.
 
-#### For Fields
+#### **For Fields**
 Owlkettle provides default `build` hooks for every field. They are useful if you need simple custom behaviour, such as modifying the input slightly before initially assigning it to a field. It is their responsibility to transfer data from `Widget` to their field in `WidgetState` during the build-phase.
 
 `build` hooks on fields should be used when additional logic is necessary that sets this single field on `WidgetState`. 
@@ -388,7 +388,7 @@ brew(gui(App()))
 
 Note that this hook is not run during updates, so any changes here may be lost if an update overwrites them. Look at the `update` hook if you need that behaviour as well.
 
-### Before-Build Hook
+### **Before-Build Hook**
 The `beforeBuild` hook runs once before the build-hook and thus also before any values are assigned to the `WidgetState`.
 
 Their main usecase is renderables, where they are used to instantiate the GTK-Widget and assign it to `internalWidget` on `WidgetState`.
@@ -426,7 +426,7 @@ But what if we want to have a parent widget decide the text to render once and t
 
 That leads us to what `afterBuild` hooks are...
 
-### After-Build Hook
+### **After-Build Hook**
 The `afterBuild`-hook runs once after initial values (default-values, values passed in by other widgets during instantiation) have been assigned to the `WidgetState`.
 
 They are useful if any processing on the initial data that is passed in must happen. Example are validating data, inferring data from passed in data, or fetching other data based on what was passed in. In renderables they are also useful to update the GTK widget once with data from the initial `WidgetState`.
@@ -465,7 +465,7 @@ brew(gui(App()))
 Note: The value of the Label is set only *once*  during build-time and never updated afterwards!
 If you want this section to be updated when the input from the parent-widget changes, you may want to look into `property` hooks.
 
-### ConnectEvents/DisconnectEvents Hook
+### **ConnectEvents/DisconnectEvents Hook**
 The `connectEvents` hook runs during the build-phase as well as during every update-phase after the `disconnectEvents` hook. The `disconnectEvents` hook meanwhile only runs during the update phase. It should be noted that triggering an event also causes an update phase to run.
 
 These hooks are only relevant for renderables, as their task is to attach/detach event-listeners stored in `WidgetState` to/from the underlying GTK-widget. 
@@ -504,10 +504,10 @@ method view(app: AppState): Widget =
 brew(gui(App()))
 ```
 
-### Update Hook
+### **Update Hook**
 `update` hooks runs every time the `Widget` updates the `WidgetState`. In other words, whenever the application is redrawn, which occurs every time an event is thrown and every time the `WidgetState.redraw` method is called.
 
-#### For Widgets
+#### **For Widgets**
 On widgets the `update` hook is for cases where you want to update fields, but using an `update` hook on a single field is not a clean solution, e.g. where fields share an expensive operation that you do not want to repeat unnecessarily. For simpler cases, consider the `property`-hook (see the `property`-hook for more) or an `update` hook on that specific field.
 
 Here an example demonstrating how the `update`-hook on a widget can be used:
@@ -543,7 +543,7 @@ method view(app: AppState): Widget =
 brew(gui(App()))
 ```
 
-#### For Fields
+#### **For Fields**
 Owlkettle provides default `update` hooks for every field. They are useful if you need simple custom behaviour, such as modifying the input slightly before updating a field with it. It is their responsibility to transfer data from `Widget` to their field in `WidgetState` as desired.
 
 Here an example for how an `update` hook on a field can be used:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -235,14 +235,17 @@ Hooks are a concept introduced by owlkettle that allows you to execute code thro
 Most hooks are defined only for Widgets, some are defined for both and `property` is only available as a hook for fields.
 
 The available hooks are:
-  - (W) beforeBuild     : Executed only once before the `WidgetState` is created.
-  - (WF) build           : Executed once after `WidgetState` is instantiated from `Widget`. Default values have not yet been applied and will overwrite any values set within this hook.
-  - (W) afterBuild      : Executed only once after the `WidgetState` was created. Is executed *after* all default values have been applied.
-  - (W) connectEvents   : Only relevant for renderables. Executed every time a callback is supposed to be attached to the underlying GTK widget. It defines how to do so.
-  - (W) disconnectEvents: Only relevant for renderables. Executed every time a callback is supposed to be removed from the underlying GTK widget. It defines how to do so.
-  - (WF) update         : Executed every time `WidgetState` is updated by `Widget`.
-  - (F) property        : Executed every time the hook-field changed its value during the update or build phases.
-  - (F) read            : Used in `Dialog`. Executes every time the state of the underlying GTK-Widget changes.
+
+|Hook Type | For renderables | For viewables | Name | Description|
+|---|---|---|---|---|
+|W | Yes | No  | BeforeBuild | Executed only once before the `WidgetState` is created.|
+|WF | Yes | Yes | Build       | Executed only once after `WidgetState` is instantiated from `Widget`. Default values have not yet been applied and will overwrite any values set within this hook.|
+| W | Yes | Yes | AfterBuild  |  Executed only once after the `WidgetState` was created. Is executed *after* all default values have been applied.|
+| W | Yes | No  | ConnectEvents  | Only relevant for renderables. Executed every time a callback is supposed to be attached to the underlying GTK widget. It defines how to do so.|
+| W | Yes | No  | DisconnectEvents  | Only relevant for renderables. Executed every time a callback is supposed to be removed from the underlying GTK widget. It defines how to do so.|
+| WF | Yes | Yes | Update | Executed every time `WidgetState` is updated by `Widget`.  |
+| F | Yes | Yes | Property  | Executed every time the hook-field changed its value during the update or build phases.|
+| F | Yes | No  | Read  | Used in `Dialog`. Executes every time the state of the underlying GTK-Widget changes. |
 
 W: Can act as hook for Widgets
 F: Can act as hook for fields

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,10 +1,129 @@
-# Owlkettle Internals
+# **Owlkettle Internals**
 
-Every widget in owlkettle is either a renderable or a viewable widget.
-Renderable widgets provide declarative interfaces to GTK widgets.
+## **Widget-Basics**
+
+Every widget in owlkettle is either a `renderable` or a `viewable` widget.
+
+`Renderable` widgets provide declarative interfaces to GTK widgets.
 For example `Button`, `Window` and `Entry` are renderable widgets.
-Viewable widgets are abstractions over renderable widgets.
-Owlkettle applications are usually implemented as viewable widgets.
+
+`Viewable` widgets are abstractions over renderable widgets.
+Owlkettle applications and any custom widgets written by you are usually implemented as viewable widgets.
+
+Regardless of that distinction, all widget consists of a `State`, which is used to generate a `Widget` instance via a `view` method.
+
+We shall go into more detail for Viewables in the next sections.
+
+## **Custom Widgets**
+To make one, just declare the `Viewable` and the fields on its state, then write a `view` method that creates the `Widget`.
+
+Let's look at a `CustomLabel` widget with a `text`-field that renders the text and another piece of text besides it.
+
+```nim
+import owlkettle 
+
+### Custom Label Widget
+viewable CustomLabel:
+  text: string
+
+method view*(state: CustomLabelState): Widget =
+  echo state.repr
+  gui:
+    Box():
+      Label(text = "I was passed the value: ")
+      Label(text = state.text)
+
+## The App
+viewable App:
+  discard
+
+method view*(state: AppState): Widget =
+  gui:
+    Window:
+      CustomLabel(text = "test")
+
+when isMainModule:
+  brew(gui(App()))
+```
+
+And that's your CustomLabel. Note though, that you can't write:
+
+```nim
+...
+method view*(state: AppState): Widget =
+  gui:
+    Window:
+      CustomLabel(text = "test"):
+        Label(text = "Also render me!")
+...
+```
+
+because CustomLabel doesn't have the ability to store or render child-Widgets!
+For that we need adders!
+
+## **Adding Widgets with Adders**
+### **One Adder**
+Not all Widgets have adders. But all Widgets that want to be passed other Widgets from the outside to contain (like `Box` for example) need at least one.
+
+To do this you must:
+1) Add a `seq[Widget]` field to your widget-state that can store child-Widgets
+2) Define an adder that enables the `seq[Widget]` field and adds widgets to it
+3) Define in your `view` method where to put the child-widgets from the widget-state
+
+An adder is a proc that enables the field that stores `seq[Widget]` and defines how to add a child-widget to it.
+It implicitly receives the parameters 1) `widget` of type `Widget` (the custom widget itself) and 2) `child` of type `Widget` (the child-widget to add).
+
+"Enabling" a field of your custom widget means that it allows an "outside"-Widget to mutate it. In this case it allows adding `Widget`s to `seq[Widget]`. Without that, manipulating the `seq[Widget]` field is not possible. 
+
+Note: Any field you define under `viewable` will be present on `widget` in the form of the boolean field `has<FieldName>` and `val<FieldName>`. `has<FieldName>` controls whether the field is dis/enabled. `val<FieldName>` is the actual field value. 
+
+Let's look at an example for a `CustomBox`:
+```nim
+import owlkettle
+
+## The custom widget
+viewable CustomBox:
+  myChildren: seq[Widget] # The seq[Widget] field
+
+  adder add: # Define the default adder `add`
+    widget.hasMyChildren = true # Enables mutating `myChildren`
+    widget.valMyChildren.add(child) # Adds the child-Widget to `myChildren`
+
+method view(state: CustomBoxState): Widget =
+  gui: 
+    Box(orient = OrientY):
+      for child in state.myChildren:
+        insert child # Inserts child-widget into this CustomBox-widget
+
+## The App
+viewable App:
+  discard
+
+method view(state: AppState): Widget =
+  gui:
+    Window:
+      CustomBox():
+        Label(text = "I was passed in from the outside")
+        Label(text = "Me too!")
+        Label(text = "Me three!")
+
+when isMainModule:
+  brew(gui(App()))
+```
+
+We define `myChildren` and "enable" it in the `add` adder via `widget.hasMyChildren = true`.
+Then we define how to add the `child` Widget to it, which in this case is simply us adding it to the seq.
+
+### **Multiple Adders**
+# TODO: Write this.
+
+### **Hooks**
+# TODO: Write this
+### **Setters**
+
+# TODO: Write this
+
+What are the hasMargin and valMargin procs for, are they things we should know about?
 
 ```mermaid
 classDiagram

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -366,9 +366,6 @@ import owlkettle
 import owlkettle/gtk
 import std/json
 
-type Config = object
-  name: string
-
 renderable MyRenderable:
   text: string
     

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -66,14 +66,14 @@ For that we need adders!
 Not all Widgets have adders. But all Widgets that want to be passed other Widgets from the outside to contain (like `Box` for example) need at least one.
 
 To do this you must:
-1) Add a `seq[Widget]` field to your widget-state that can store child-Widgets
-2) Define an adder that enables the `seq[Widget]` field and adds widgets to it
+1) Add a field to your widget-state that can store child-Widgets (e.g. one with type `seq[Widget]`)
+2) Define an adder that enables the child-widget-field and adds a given widget to it
 3) Define in your `view` method where to put the child-widgets from the widget-state
 
-An adder is a proc that enables the field that stores `seq[Widget]` and defines how to add a child-widget to it.
+An adder is a proc that enables the field that stores child-widgets and defines how to add widgets to that field.
 It implicitly receives the parameters 1) `widget` of type `Widget` (the custom widget itself) and 2) `child` of type `Widget` (the child-widget to add).
 
-"Enabling" a field of your custom widget means that it allows an "outside"-Widget to mutate it. In this case it allows adding `Widget`s to `seq[Widget]`. Without that, manipulating the `seq[Widget]` field is not possible. 
+"Enabling" a field of your custom widget means that it allows an "outside"-Widget to mutate it. In this case it allows adding `Widget`s to the child-widget-field. Without that, manipulating the child-widget-field field is not possible. 
 
 Note: Any field you define under `viewable` will be present on `widget` in the form of the boolean field `has<FieldName>` and `val<FieldName>`. `has<FieldName>` controls whether the field is dis/enabled. `val<FieldName>` is the actual field value. 
 
@@ -83,7 +83,7 @@ import owlkettle
 
 ## The custom widget
 viewable CustomBox:
-  myChildren: seq[Widget] # The seq[Widget] field
+  myChildren: seq[Widget] # The child-widget field
 
   adder add: # Define the default adder `add`
     widget.hasMyChildren = true # Enables mutating `myChildren`
@@ -114,16 +114,120 @@ when isMainModule:
 We define `myChildren` and "enable" it in the `add` adder via `widget.hasMyChildren = true`.
 Then we define how to add the `child` Widget to it, which in this case is simply us adding it to the seq.
 
+But what if we want to store child-widgets in a table-field on `CustomBox` ? We would need to pass the key to store the child-widget under to the adder...
+### **Adders with properties**
+Let's make a custom widget that stores Widgets in a `Table[string, Widget]` and displays the widget next to the key it was stored with.
+
+First we need to modify our adder, telling it that there will be additional parameters. 
+
+```nim
+...
+viewable CustomBox:
+  myChildren: Table[string, Widget] # The child-widget field
+
+  adder add {.key: none(string).}: 
+...
+``` 
+Additional parameters passed to adders like that are called "properties". Properties **must** have a default value, their type is inferred based on that value. If you do not want to provide a default value, you can use an `Option` type.
+
+Let's assert that anyone using `CustomBox` also passes a key and doesn't accidentally reuse a key that has already been used to store a Widget that in the table:
+
+```nim
+viewable CustomBox:
+  myChildren: Table[string, Widget] # The child-widget field
+
+  adder add {.key: none(string).}: 
+    assert key.isSome(), "CustomBox requires you to tell it under which key to store child widgets. Add a 'key' property"
+    
+    let keyIsFree = not widget.valMyChildren.hasKey(key.get()) 
+    assert keyIsFree, fmt"A widget with the key '{key.get()} has already been added to CustomBox. Use a different name"
+
+    widget.hasMyChildren = true 
+    widget.valMyChildren[key.get()] = child
+
+method view(state: CustomBoxState): Widget =
+  gui: 
+    Box(orient = OrientY):
+      for key in state.myChildren.keys:
+        Box():
+          Label(text = key)
+          insert state.myChildren[key]
+
+## The App
+viewable App:
+  discard
+
+method view(state: AppState): Widget =
+  gui:
+    Window:
+      CustomBox():
+        Label(text = "I was passed in from the outside") {.key: some("key1").}
+        Label(text = "Me too!") {.key: some("key2").}
+        Label(text = "Me three!") {.key: some("key3").}
+        # Label(text = "Me four!") {.key: some("key3").} # Will cause a runtime error because key3 is already in use
+
+when isMainModule:
+  brew(gui(App()))
+```
+
+If we were to remove the "#" in front of the last Label, we would be facing a runtime error produced by the application, since "key3" was already used.
+
+Note: When using optionals, due to the macros involved, you can only use the `some(<value>)`/`none(<typedesc>)` syntax.
+
 ### **Multiple Adders**
-# TODO: Write this.
+In addition to passing properties to an adder, you can naturally also have multiple different adders. They just need different names.
+
+Let's look at a `CustomBox` widget with 2 `seq[Widget]` fields that you add to with different adders:
+
+```nim
+import owlkettle
+
+viewable CustomBox:
+  myChildren1: seq[Widget]
+  myChildren2: seq[Widget]
+
+  adder add: 
+    widget.hasMyChildren1 = true 
+    widget.valMyChildren1.add child
+  
+  adder add2:
+    widget.hasMyChildren2 = true
+    widget.valMyChildren2.add child
+
+method view(state: CustomBoxState): Widget =
+  gui: 
+    Box(orient = OrientY):
+      Box():
+        Label(text = "First Box")
+        for widget in state.myChildren1:
+          insert widget
+        
+      Box():
+        Label(text = "Second Box")
+        for widget in state.myChildren2:
+          insert widget
+
+## The App
+viewable App:
+  discard
+
+method view(state: AppState): Widget =
+  gui:
+    Window:
+      CustomBox():
+        Label(text = "I was passed in from the outside") # Uses "add"-adder implicitly by default 
+        Label(text = "Me too!") {.add.} # Uses "add"-adder explicitly
+        Label(text = "Me three!") {.add2.} # Uses "add2"-adder explicitly
+
+when isMainModule:
+  brew(gui(App()))
+```
+
+If no adder is specified, `Widget`s will always be added using the `add` adder. Otherwise the adder defined by the pragma annotation will be used.
 
 ### **Hooks**
 # TODO: Write this
-### **Setters**
 
-# TODO: Write this
-
-What are the hasMargin and valMargin procs for, are they things we should know about?
 
 ```mermaid
 classDiagram

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -558,7 +558,8 @@ viewable MyViewable:
   hooks text:
     update:
       echo "Received via Widget:    ", widget.valText
-      state.text = widget.valText & " update hook addition"
+      if widget.hasText:
+        state.text = widget.valText & " update hook addition"
       echo "Applied to WidgetState: ", state.text
 
 method view(state: MyViewableState): Widget =
@@ -580,6 +581,8 @@ brew(gui(App()))
 ```
 
 Note that this hook is not run initially, so when the widget is first being built these changes are likely not applied yet. Look at the `build` hook if you need that behaviour, or `property` hook if you need both.
+
+Also note that we checked if the `Widget.hasText` value is true before assigning values to that field. This check is useful as widgets may disable their field, in which case their updates should not be propagated back to the `WidgetState`.
 
 ### **Property Hook**
 `property` hooks run every time the hook-field changed its value during either the update or build phases. They are called by the default `build` and `update` field hooks near the end of their runtime and exist mostly for convenience. If you want to have the same additional behaviour during build and update phases, you can define a `property` hook instead of a `build` and `update` hook.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -230,7 +230,6 @@ when isMainModule:
 If no adder is specified, `Widget`s will always be added using the `add` adder. Otherwise the adder defined by the pragma annotation will be used.
 
 ### **Hooks**
-
 Hooks are a concept introduced by owlkettle that allows you to execute code throughout a widget's lifecycle, or when an action on one of its fields occurs.
 
 Most hooks are defined only for Widgets, some are defined for both and `property` is only available as a hook for fields.
@@ -252,7 +251,7 @@ All hooks have implicit access to a variable called `state`, which contains the 
 
 With the exception of `read`, all hooks also have implicit access to a variable called `widget`, which is the `Widget` instance.
 
-Generally the `build` and `update` hook are likely to have the highest utility for you. Consult their individual sections for more information.
+Generally the `build`, `property` and `update` hooks are likely to have the highest utility for you. Consult their individual sections for more information.
 
 #### Build Hook
 The `build` hook runs once just before any values are assigned to the `WidgetState`.
@@ -290,7 +289,6 @@ method view(state: AppState): Widget =
 
 brew(gui(App()))
 ```
-
 
 `build` hooks also are inherited from the parent-widget. In those scenarios, during the build-phase owlkettle will first execute the `build` hook of the parent and then the `build` hook of the child.
 
@@ -427,8 +425,7 @@ Note: The value of the Label is set only *once*  during build-time and never upd
 If you want this section to be updated when the input from the parent-widget changes, you may want to look into `property` hooks.
 
 #### ConnectEvents/DisconnectEvents Hook
-
-The `connectEvents` hook runs during the build-phase as well as during every update-phase after the `disconnectEvents` hook. The `disconnectEvents` hook meanwhile only runs during the update phase. 
+The `connectEvents` hook runs during the build-phase as well as during every update-phase after the `disconnectEvents` hook. The `disconnectEvents` hook meanwhile only runs during the update phase. It should be noted that triggering an event also causes an update phase to run.
 
 These hooks are only relevant for renderables, as their task is to attach/detach event-listeners stored in `WidgetState` to/from the underlying GTK-widget. 
 
@@ -467,7 +464,42 @@ brew(gui(App()))
 ```
 
 #### Update Hook
-# TODO: Write this
+The `update` hook runs every time the `Widget` updates the `WidgetState`. In other words, whenever the application is redrawn, which occurs every time an event is thrown and every time the `WidgetState.redraw` method is called.
+
+It is best used for scenarios where multiple fields are inferred from other fields in a complex manner, or where inferring data is expensive and you need to first assert that it is necessary before doing the calculations. For simpler cases, consider the `property`-hook (see the `property`-hook for more).
+
+Here an example demonstrating how the `update`-hook can be used:
+
+```nim
+import owlkettle
+
+## The custom widget
+viewable MyViewable:
+  text: string
+
+  hooks:
+    update:
+      echo "Original Value: ", state.text
+      state.text = state.text & " - Addition"
+      echo "New Value     : ", state.text
+
+method view(state: MyViewableState): Widget =
+  gui:
+    Button(text = state.text):
+      proc clicked() =
+        echo "Event triggering update"
+
+## The App
+viewable App:
+  discard
+
+method view(app: AppState): Widget =
+  result = gui:
+    Window:
+      MyViewable(text = "Defined by App")
+
+brew(gui(App()))
+```
 
 #### Property Hook
 # TODO: Write this

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -12,6 +12,8 @@ Owlkettle applications and any custom widgets written by you are usually impleme
 
 Regardless of that distinction, all widget consists of a `State`, which is used to generate a `Widget` instance via a `view` method.
 
+Any field on a `State` is represented on the generated Widget via the fields `has<Field>` and `val<Field>`.
+
 We shall go into more detail for Viewables in the next sections.
 
 ## **Custom Widgets**
@@ -248,10 +250,65 @@ All hooks have implicit access to a variable called `state`, which contains the 
 
 With the exception of `read`, all hooks also have implicit access to a variable called `widget`, which is the `Widget` instance.
 
-#### Build-Hook
-The intended usecase for build-hooks is writing custom-constructors (read: procs that fill the widget's `State`)
+Generally the `build` and `update` hook are likely to have the highest utility for you. Consult their individual sections for more information.
 
-# TODO: Finish writing this
+#### Build Hook
+The intended usecase for build-hooks is adding logic that sets fields on `WidgetState` that don't have default-values.
+
+One such usecase could be that a Widget may need to load data from elsewhere, like a file or via HTTP request from the internet. Doing this in the `view` method would cause you to rerun the code every time the widget re-renders. By putting it in a build-hook you make sure that code only runs once.
+
+Here a simple example for useage:
+```nim
+import std/json
+
+type Config = object
+  name: string
+
+viewable MyViewable:
+  config: Config
+    
+  hooks:
+    build:
+      state.config = "./src/bla.json".readFile().parseJson().to(Config)
+
+method view(state: MyViewableState): Widget =
+  result = gui:
+    Label:
+      text = state.config.name
+
+
+## The App
+viewable App:
+  discard
+
+method view(app: AppState): Widget =
+  result = gui:
+    Window:
+      MyViewable()
+
+brew(gui(App()))
+```
+
+#### Before-Build Hook
+# TODO: Write this
+
+#### After-Build Hook
+# TODO: Write this
+
+#### ConnectEvents Hook
+# TODO: Write this
+
+#### DisconnectEvents Hook
+# TODO: Write this
+
+#### Update Hook
+# TODO: Write this
+
+#### Property Hook
+# TODO: Write this
+
+#### Read Hook
+# TODO: Write this
 
 ### **Custom CSS**
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -369,10 +369,7 @@ renderable MyRenderable:
   hooks:
     beforeBuild:
       echo state.repr
-      state.internalWidget = gtk_label_new("")
-
-    afterBuild:
-      gtk_label_set_text(state.internalWidget, state.text.cstring)
+      state.internalWidget = gtk_label_new("ExampleText")
 
 viewable App:
   discard
@@ -380,12 +377,13 @@ viewable App:
 method view(app: AppState): Widget =
   result = gui:
     Window:
-      MyRenderable(text = "potato")
+      MyRenderable()
 
 brew(gui(App()))
 ```
 
-Note how we had to set the actual value in a `afterBuild` hook, because the value assigned by the App (`"potato"`) is passed in *after* the build-stage. Usually you would use a `property` hook, but `afterBuild` hooks are simpler to explain for now.
+We set the label-text to render directly via the `gtk_label_new` proc.
+But what if we want to have a parent widget decide the text to render once and then never update it again?  
 
 That leads us to what `afterBuild` hooks are...
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -264,32 +264,29 @@ Example: A Widget may need to load data from elsewhere, via a file or HTTP reque
 Here a simple code-example:
 
 ```nim
+# example.json
+{"name":"example"}
+
+# main.nim
 import std/json
+import owlkettle
+import owlkettle/gtk
 
 type Config = object
   name: string
 
-viewable MyViewable:
+viewable App:
   config: Config
-    
+
   hooks:
     build:
-      state.config = "./src/bla.json".readFile().parseJson().to(Config)
+      state.config = "./src/example.json".readFile().parseJson().to(Config)
 
-method view(state: MyViewableState): Widget =
-  result = gui:
-    Label:
-      text = state.config.name
-
-
-## The App
-viewable App:
-  discard
-
-method view(app: AppState): Widget =
+method view(state: AppState): Widget =
   result = gui:
     Window:
-      MyViewable()
+      Label:
+        text = state.config.name
 
 brew(gui(App()))
 ```

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -375,11 +375,45 @@ method view(app: AppState): Widget =
 brew(gui(App()))
 ```
 
-#### ConnectEvents Hook
-# TODO: Write this
+#### ConnectEvents/DisconnectEvents Hook
 
-#### DisconnectEvents Hook
-# TODO: Write this
+The `connectEvents` hook runs during the build-phase as well as during every update-phase after the `disconnectEvents` hook. The `disconnectEvents` hook meanwhile only runs during the update phase. 
+
+These hooks are only relevant for renderables, as their task is to attach/detach event-listeners stored in `WidgetState` to/from the underlying GTK-widget. 
+
+Here a minimal example of a custom button widget that connects an event-listener proc to the gtk click event and disconnects it on update:
+
+```nim
+import owlkettle
+import std/tables
+import owlkettle/[widgetutils, gtk]
+
+renderable MyButton of BaseWidget:  
+  proc clicked()
+  
+  hooks:
+    beforeBuild:
+      state.internalWidget = gtk_button_new()
+
+    connectEvents:
+      echo "Connect"
+      state.connect(state.clicked, "clicked", eventCallback)
+    
+    disconnectEvents:
+      echo "Disconnect"
+      state.internalWidget.disconnect(state.clicked)
+
+viewable App:
+  discard
+
+method view(app: AppState): Widget =
+  result = gui:
+    Window:
+      MyButton():
+        proc clicked() = echo "Potato"
+
+brew(gui(App()))
+```
 
 #### Update Hook
 # TODO: Write this

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -388,7 +388,7 @@ brew(gui(App()))
 
 Note that this hook is not run during updates, so any changes here may be lost if an update overwrites them. Look at the `update` hook if you need that behaviour, or `property` hook if you need both.
 
-### **Before-Build Hook**
+### **BeforeBuild Hook**
 The `beforeBuild` hook runs once before the build-hook and thus also before any values are assigned to the `WidgetState`.
 
 Their main usecase is renderables, where they are used to instantiate the GTK-Widget and assign it to `internalWidget` on `WidgetState`.
@@ -426,7 +426,7 @@ But what if we want to have a parent widget decide the text to render once and t
 
 That leads us to what `afterBuild` hooks are...
 
-### **After-Build Hook**
+### **AfterBuild Hook**
 The `afterBuild`-hook runs once after initial values (default-values, values passed in by other widgets during instantiation) have been assigned to the `WidgetState`.
 
 They are useful if any processing on the initial data that is passed in must happen. Example are validating data, inferring data from passed in data, or fetching other data based on what was passed in. In renderables they are also useful to update the GTK widget once with data from the initial `WidgetState`.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -255,7 +255,7 @@ With the exception of `read`, all hooks also have implicit access to a variable 
 Generally the `build` and `update` hook are likely to have the highest utility for you. Consult their individual sections for more information.
 
 #### Build Hook
-The `build` hook runs just before any values are assigned to the `WidgetState`.
+The `build` hook runs once just before any values are assigned to the `WidgetState`.
 
 The intended usecase for build-hooks is adding logic that sets fields on `WidgetState` that don't have default-values.
 
@@ -292,7 +292,7 @@ brew(gui(App()))
 ```
 
 
-`build` hooks also are inherited from the parent-component. In those scenarios, during the build-phase owlkettle will first execute the `build` hook of the parent and then the `build` hook of the child.
+`build` hooks also are inherited from the parent-widget. In those scenarios, during the build-phase owlkettle will first execute the `build` hook of the parent and then the `build` hook of the child.
 
 To demonstrate this, here a small example:
 
@@ -350,7 +350,7 @@ Given that the purpose of `beforeBuild` is to handle instantiating renderables a
 For more info on the purpose of `beforeBuild` and `afterBuild` hooks, consult their respective sections in this file.
 
 #### Before-Build Hook
-The `beforeBuild` hook runs before the build-hook and thus also before any values are assigned to the `WidgetState`.
+The `beforeBuild` hook runs once before the build-hook and thus also before any values are assigned to the `WidgetState`.
 
 Their main usecase is renderables, where they are used to instantiate the GTK-Widget and assign it to `internalWidget` on `WidgetState`.
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -226,6 +226,35 @@ when isMainModule:
 If no adder is specified, `Widget`s will always be added using the `add` adder. Otherwise the adder defined by the pragma annotation will be used.
 
 ### **Hooks**
+
+Hooks are a concept introduced by owlkettle that allows you to execute code throughout a widget's lifecycle, or when an action on one of its fields occurs.
+
+Most hooks are defined only for Widgets, some are defined for both and `property` is only available as a hook for fields.
+
+The available hooks are:
+  - (W) beforeBuild     : Executed only once before the `WidgetState` is created.
+  - (WF) build           : Executed once after `WidgetState` is instantiated from `Widget`. Default values have not yet been applied and will overwrite any values set within this hook.
+  - (W) afterBuild      : Executed only once after the `WidgetState` was created. Is executed *after* all default values have been applied.
+  - (W) connectEvents   : Only relevant for renderables. Executed every time a callback is supposed to be attached to the underlying GTK widget. It defines how to do so.
+  - (W) disconnectEvents: Only relevant for renderables. Executed every time a callback is supposed to be removed from the underlying GTK widget. It defines how to do so.
+  - (WF) update         : Executed every time `WidgetState` is updated by `Widget`.
+  - (F) property        : Executed every time the hook-field changed its value in both the update and build phases.
+  - (F) read            : Used in `Dialog`. Executes every time the state of the underlying GTK-Widget changes.
+
+W: Can act as hook for Widgets
+F: Can act as hook for fields
+
+All hooks have implicit access to a variable called `state`, which contains the `WidgetState`-instance of your particular widget.
+
+With the exception of `read`, all hooks also have implicit access to a variable called `widget`, which is the `Widget` instance.
+
+#### Build-Hook
+The intended usecase for build-hooks is writing custom-constructors (read: procs that fill the widget's `State`)
+
+# TODO: Finish writing this
+
+### **Custom CSS**
+
 # TODO: Write this
 
 

--- a/docs/recommended_tools.md
+++ b/docs/recommended_tools.md
@@ -20,7 +20,15 @@ For an overview over the color-palette used by gnome, you can install [ColorPale
 
 Generally when developing with custom colors you may want to ensure that the contrast difference between e.g. text and background is sufficient to be easy to read. This is particularly important for accessibility! 
 
-To check if the contrast between 2 pixels on your desktop is large enough, you can use [Contrast](https://flathub.org/apps/details/org.gnome.design.Contrast).
+To check if the contrast between 2 pixels on your desktop is large enough, you can install [Contrast](https://flathub.org/apps/details/org.gnome.design.Contrast).
+
+## GTK Documentation
+
+When using Widgets such as [ListBox](https://github.com/can-lehmann/owlkettle/blob/main/docs/widgets.md#listbox) you are likely to stumble over enums whose meaning depends on GTK4.
+
+To look for such symbols in the GTK4 documentation, you can install [DevHelp](https://apps.gnome.org/app/org.gnome.Devhelp/). To download the docs themselves, you will need to install an additional package:
+- Fedora/RHEL: gtk4-devel-docs
+- Arch: gtk4-docs
 
 ## Further applications
 

--- a/docs/recommended_tools.md
+++ b/docs/recommended_tools.md
@@ -2,6 +2,14 @@
 
 A list of tools to help with developing owlkettle/gtk4 applications.
 
+## Inspecting your applications CSS/Actions/CSS-Nodes and more
+
+Often times you need to figure how much space a given component takes up, play around with the CSS it uses or you may just want to inspect the component tree yourself.
+
+For all kinds of such things, there is a tool provided by GTK called [GTK-Inspector](https://wiki.gnome.org/Projects/GTK/Inspector). You may need to enable it, consult the wiki for further information.
+
+To open it, press CTRL+SHIFT+I.
+
 ## Icons
 
 Some Widgets such as [Buttons](https://github.com/can-lehmann/owlkettle/blob/main/docs/widgets.md#button) come with `icon`-setters, that you provide a gtk4-icon-string and it will render the corresponding icon.

--- a/docs/recommended_tools.md
+++ b/docs/recommended_tools.md
@@ -1,0 +1,27 @@
+# Recommended Development Tools
+
+A list of tools to help with developing owlkettle/gtk4 applications.
+
+## Icons
+
+Some Widgets such as [Buttons](https://github.com/can-lehmann/owlkettle/blob/main/docs/widgets.md#button) come with `icon`-setters, that you provide a gtk4-icon-string and it will render the corresponding icon.
+
+For an overview over which icons are available, you can install the [GTK4 Icon-Library Application](https://apps.gnome.org/app/org.gnome.design.IconLibrary).
+
+For using custom icons and icon-sets, you may want to look into [Symbolic-Preview](https://flathub.org/apps/details/org.gnome.design.SymbolicPreview).
+
+## Colors
+
+When usign custom stylesheet with owlkettle and changing colors, you may want to choose colors that integrate well into the color-palette used by the GNOME Desktop Environment.
+
+For an overview over the color-palette used by gnome, you can install [ColorPalette](https://apps.gnome.org/app/org.gnome.design.Palette/).
+
+## Contrast
+
+Generally when developing with custom colors you may want to ensure that the contrast difference between e.g. text and background is sufficient to be easy to read. This is particularly important for accessibility! 
+
+To check if the contrast between 2 pixels on your desktop is large enough, you can use [Contrast](https://flathub.org/apps/details/org.gnome.design.Contrast).
+
+## Further applications
+
+You can find more applications to help with development [here](https://tools.design.gnome.org/)

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,10 +1,4 @@
 # Widgets
-
-## Custom Widgets
-When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
-  - BaseWidget-fields and setters
-
-
 ## BaseWidget
 
 ```nim
@@ -170,7 +164,7 @@ if `useMarkup` is enabled.
 - `text: string` The text of the Label to render
 - `xAlign: float = 0.5`
 - `yAlign: float = 0.5`
-- `ellipsize: EllipsizeMode` Determines whether to ellipsise the text in case space is insufficient to render all of it.
+- `ellipsize: EllipsizeMode` Determines whether to ellipsise the text in case space is insufficient to render all of it. May be one of `EllipsizeNone`, `EllipsizeStart`, `EllipsizeMiddle` or `EllipsizeEnd`
 - `wrap: bool = false` Enables/Disable wrapping of text.
 - `useMarkup: bool = false` Determines whether to interpret the given text as Pango Markup or not.
 - `style: set[LabelStyle]` The style of the text used. May be one of `LabelHeading`, `LabelBody` or `LabelMonospace`.
@@ -232,7 +226,7 @@ renderable Button of BaseWidget
 ###### Fields
 
 - All fields from [BaseWidget](#BaseWidget)
-- `style: set[ButtonStyle]` Applies special styling to the button.
+- `style: set[ButtonStyle]` Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
 - `child: Widget`
 - `shortcut: string` Keyboard shortcut
 
@@ -664,7 +658,7 @@ renderable MenuButton of BaseWidget
 - All fields from [BaseWidget](#BaseWidget)
 - `child: Widget`
 - `popover: Widget`
-- `style: set[ButtonStyle]` Applies special styling to the button.
+- `style: set[ButtonStyle]` Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
 
 ###### Setters
 
@@ -959,7 +953,7 @@ renderable DialogButton
 
 - `text: string`
 - `response: DialogResponse`
-- `style: set[ButtonStyle]` Applies special styling to the button.
+- `style: set[ButtonStyle]` Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
 
 ###### Setters
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,12 +1,10 @@
-    # Widgets
+# Widgets
 
-    ## Custom Widgets
-    When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
-      - BaseWidget-fields and setters
+## Custom Widgets
+When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
+  - BaseWidget-fields and setters
 
-    ## Owlkettle Widgets
-    \n\n
-  
+
 ## BaseWidget
 
 ```nim

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,11 +1,20 @@
-# Widgets
+    # Widgets
 
+    ## Custom Widgets
+    When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
+      - BaseWidget-fields and setters
 
+    ## Owlkettle Widgets
+    \n\n
+  
 ## BaseWidget
 
 ```nim
 renderable BaseWidget
 ```
+
+The base widget of all widgets. Supports redrawing the entire Application
+by calling `<WidgetName>State.app.redraw()
 
 ###### Fields
 
@@ -75,7 +84,7 @@ A Box arranges its child widgets along one dimension.
 ###### Fields
 
 - All fields from [BaseWidget](#BaseWidget)
-- `orient: Orient` Orientation of the Box. May be one of OrientX or OrientY
+- `orient: Orient` Orientation of the Box and its containing elements. May be one of OrientX (to orient horizontally) or OrientY (to orient vertically)
 - `spacing: int` Spacing between the children of the Box
 - `children: seq[BoxChild[Widget]]`
 - `style: set[BoxStyle]`
@@ -85,8 +94,11 @@ A Box arranges its child widgets along one dimension.
 - All adders from [BaseWidget](#BaseWidget)
 - `add` Adds a child to the Box.
 When expand is true, the child grows to fill up the remaining space in the Box.
-The hAlign and vAlign properties allow you to set the alignment of the child
-within its allocated area.
+The hAlign and vAlign properties allow you to set the horizontal and vertical 
+alignment of the child within its allocated area. They may be one of `AlignFill`, 
+`AlignStart`, `AlignEnd` or `AlignCenter`.
+
+Note: **Any** widgets contained in a Box-Widget get access the `expand` adder, to control their behaviour inside of the Box!
 
   - `expand = true`
   - `hAlign = AlignFill`
@@ -150,16 +162,20 @@ renderable Overlay of BaseWidget
 renderable Label of BaseWidget
 ```
 
+The default widget to display text.
+Supports rendering [Pango Markup](https://docs.gtk.org/Pango/pango_markup.html#pango-markup) 
+if `useMarkup` is enabled.
+
 ###### Fields
 
 - All fields from [BaseWidget](#BaseWidget)
-- `text: string`
+- `text: string` The text of the Label to render
 - `xAlign: float = 0.5`
 - `yAlign: float = 0.5`
-- `ellipsize: EllipsizeMode`
-- `wrap: bool = false`
-- `useMarkup: bool = false`
-- `style: set[LabelStyle]`
+- `ellipsize: EllipsizeMode` Determines whether to ellipsise the text in case space is insufficient to render all of it.
+- `wrap: bool = false` Enables/Disable wrapping of text.
+- `useMarkup: bool = false` Determines whether to interpret the given text as Pango Markup or not.
+- `style: set[LabelStyle]` The style of the text used. May be one of `LabelHeading`, `LabelBody` or `LabelMonospace`.
 
 ###### Example
 
@@ -193,7 +209,7 @@ renderable Icon of BaseWidget
 
 - All fields from [BaseWidget](#BaseWidget)
 - `name: string` See [recommended_tools.md](recommended_tools.md#icons) for a list of icons.
-- `pixelSize: int = -1`
+- `pixelSize: int = -1` Determines the size of the icon
 
 ###### Example
 
@@ -218,7 +234,7 @@ renderable Button of BaseWidget
 ###### Fields
 
 - All fields from [BaseWidget](#BaseWidget)
-- `style: set[ButtonStyle]`
+- `style: set[ButtonStyle]` Applies special styling to the button.
 - `child: Widget`
 - `shortcut: string` Keyboard shortcut
 
@@ -287,6 +303,10 @@ renderable HeaderBar of BaseWidget
 
 - All adders from [BaseWidget](#BaseWidget)
 - `addTitle` Adds a custom title widget to the HeaderBar.
+When expand is true, it grows to fill up the remaining space in the headerbar.
+The hAlign and vAlign properties allow you to set the horizontal and vertical 
+alignment of the child within its allocated area. They may be one of `AlignFill`, 
+`AlignStart`, `AlignEnd` or `AlignCenter`.
 
   - `expand = false`
   - `hAlign = AlignFill`
@@ -646,7 +666,7 @@ renderable MenuButton of BaseWidget
 - All fields from [BaseWidget](#BaseWidget)
 - `child: Widget`
 - `popover: Widget`
-- `style: set[ButtonStyle]`
+- `style: set[ButtonStyle]` Applies special styling to the button.
 
 ###### Setters
 
@@ -941,7 +961,7 @@ renderable DialogButton
 
 - `text: string`
 - `response: DialogResponse`
-- `style: set[ButtonStyle]`
+- `style: set[ButtonStyle]` Applies special styling to the button.
 
 ###### Setters
 

--- a/owlkettle.nimble
+++ b/owlkettle.nimble
@@ -21,3 +21,6 @@ task examples, "Build examples":
       exec "nim c --hints:off --verbosity:0 " & file
       echo "INFO: OK"
       echo "================================================================================"
+
+task genDocs, "Generate owlkettle docs":
+  exec "make -C docs"

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -34,6 +34,8 @@ type Margin* = object
   top*, bottom*, left*, right*: int
 
 renderable BaseWidget:
+  ## The base widget of all widgets. Supports redrawing the entire Application
+  ## by calling `<WidgetName>State.app.redraw()
   sensitive: bool = true ## If the widget is interactive
   sizeRequest: tuple[x, y: int] = (-1, -1) ## Requested widget size. A value of -1 means that the natural size of the widget will be used.
   internalMargin {.internal.}: Margin = Margin()

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -28,14 +28,7 @@ when defined(nimPreviewSlimSystem):
 import gtk, widgetdef, cairo, widgetutils
 
 when defined(owlkettleDocs) and isMainModule:
-  echo """
-# Widgets
-
-## Custom Widgets
-When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
-  - BaseWidget-fields and setters
-
-"""
+  echo "# Widgets"
 
 type Margin* = object
   top*, bottom*, left*, right*: int

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -396,7 +396,7 @@ renderable Label of BaseWidget:
 
 renderable Icon of BaseWidget:
   name: string ## See [recommended_tools.md](recommended_tools.md#icons) for a list of icons.
-  pixelSize: int = -1
+  pixelSize: int = -1 ## Determines the size of the icon
   
   hooks:
     beforeBuild:
@@ -427,7 +427,9 @@ type ButtonStyle* = enum
   ButtonCircular = "circular"
 
 renderable Button of BaseWidget:
-  style: set[ButtonStyle]
+  style: set[ButtonStyle] ## Applies special styling to the button. 
+  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
+  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   child: Widget
   shortcut: string ## Keyboard shortcut
   
@@ -1330,7 +1332,9 @@ renderable MenuButton of BaseWidget:
   child: Widget
   popover: Widget
   
-  style: set[ButtonStyle]
+  style: set[ButtonStyle] ## Applies special styling to the button. 
+  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
+  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   hooks:
     beforeBuild:
@@ -2111,7 +2115,9 @@ proc toGtk(resp: DialogResponse): cint =
 renderable DialogButton:
   text: string
   response: DialogResponse
-  style: set[ButtonStyle]
+  style: set[ButtonStyle] ## Applies special styling to the button. 
+  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
+  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   setter res: DialogResponseKind
 

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -1346,9 +1346,7 @@ renderable MenuButton of BaseWidget:
   child: Widget
   popover: Widget
   
-  style: set[ButtonStyle] ## Applies special styling to the button. 
-  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
-  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   hooks:
     beforeBuild:
@@ -2129,9 +2127,7 @@ proc toGtk(resp: DialogResponse): cint =
 renderable DialogButton:
   text: string
   response: DialogResponse
-  style: set[ButtonStyle] ## Applies special styling to the button. 
-  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
-  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   setter res: DialogResponseKind
 

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -38,7 +38,7 @@ renderable BaseWidget:
   ## by calling `<WidgetName>State.app.redraw()
   sensitive: bool = true ## If the widget is interactive
   sizeRequest: tuple[x, y: int] = (-1, -1) ## Requested widget size. A value of -1 means that the natural size of the widget will be used.
-  internalMargin {.internal.}: Margin = Margin()
+  internalMargin {.internal.}: Margin = Margin() ## Allows setting top, bottom, left and right margin of a widget. Margin has those names as fields to set integer values to.
   tooltip: string = "" ## The widget's tooltip is shown on hover
   
   hooks sensitive:
@@ -156,7 +156,7 @@ proc assignApp[T](child: BoxChild[T], app: Viewable) =
 
 renderable Box of BaseWidget:
   ## A Box arranges its child widgets along one dimension.
-  orient: Orient ## Orientation of the Box. May be one of OrientX or OrientY
+  orient: Orient ## Orientation of the Box and its containing elements. May be one of OrientX (to orient horizontally) or OrientY (to orient vertically)
   spacing: int ## Spacing between the children of the Box
   children: seq[BoxChild[Widget]]
   style: set[BoxStyle]

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -323,7 +323,11 @@ type LabelStyle* = enum
   LabelMonospace = "monospace"
 
 type EllipsizeMode* = enum
-  EllipsizeNone, EllipsizeStart, EllipsizeMiddle, EllipsizeEnd
+  ## Determines whether to ellipsize text when text does not fit in a given space
+  EllipsizeNone ## Do not ellipsize 
+  EllipsizeStart, ## Start ellipsizing at the start of the text
+  EllipsizeMiddle, ## Start ellipsizing in the middle of the text
+  EllipsizeEnd ## Start ellipsizing at the end of the text
 
 renderable Label of BaseWidget:
   ## The default widget to display text.
@@ -333,10 +337,11 @@ renderable Label of BaseWidget:
   xAlign: float = 0.5
   yAlign: float = 0.5
   ellipsize: EllipsizeMode ## Determines whether to ellipsise the text in case space is insufficient to render all of it.
+  ## May be one of `EllipsizeNone`, `EllipsizeStart`, `EllipsizeMiddle` or `EllipsizeEnd`
   wrap: bool = false ## Enables/Disable wrapping of text.
   useMarkup: bool = false ## Determines whether to interpret the given text as Pango Markup or not.
   
-  style: set[LabelStyle]
+  style: set[LabelStyle] ## The style of the text used. May be one of `LabelHeading`, `LabelBody` or `LabelMonospace`.
   
   hooks:
     beforeBuild:

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -28,7 +28,17 @@ when defined(nimPreviewSlimSystem):
 import gtk, widgetdef, cairo, widgetutils
 
 when defined(owlkettleDocs) and isMainModule:
-  echo "# Widgets\n\n"
+  echo """
+    # Widgets
+
+    ### Custom Widgets
+    When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
+      - BaseWidget-fields and setters
+      - The `expand`-Adder - Determines whether a widget expands to take up all available space to it or not
+
+    It should be noted that widgets can be annotated with *any* Adder, even those that don't exist. Invalid adders and those that don't exist will be silently ignored by owlkettle and have no effect, so only use Adders that are documented for the given widget. 
+    \n\n
+  """
 
 type Margin* = object
   top*, bottom*, left*, right*: int

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -29,15 +29,13 @@ import gtk, widgetdef, cairo, widgetutils
 
 when defined(owlkettleDocs) and isMainModule:
   echo """
-    # Widgets
+# Widgets
 
-    ## Custom Widgets
-    When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
-      - BaseWidget-fields and setters
+## Custom Widgets
+When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
+  - BaseWidget-fields and setters
 
-    ## Owlkettle Widgets
-    \n\n
-  """
+"""
 
 type Margin* = object
   top*, bottom*, left*, right*: int

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -31,12 +31,11 @@ when defined(owlkettleDocs) and isMainModule:
   echo """
     # Widgets
 
-    ### Custom Widgets
+    ## Custom Widgets
     When writing your application or custom widgets you will typically be writing a `viewable` (see [internals.md](https://github.com/can-lehmann/owlkettle/blob/main/docs/internals.md) for more information). All `viewables` have the following available to them by default:
       - BaseWidget-fields and setters
-      - The `expand`-Adder - Determines whether a widget expands to take up all available space to it or not
 
-    It should be noted that widgets can be annotated with *any* Adder, even those that don't exist. Invalid adders and those that don't exist will be silently ignored by owlkettle and have no effect, so only use Adders that are documented for the given widget. 
+    ## Owlkettle Widgets
     \n\n
   """
 
@@ -258,6 +257,8 @@ renderable Box of BaseWidget:
     ## The hAlign and vAlign properties allow you to set the horizontal and vertical 
     ## alignment of the child within its allocated area. They may be one of `AlignFill`, 
     ## `AlignStart`, `AlignEnd` or `AlignCenter`.
+    ## 
+    ## Note: **Any** widgets contained in a Box-Widget get access the `expand` adder, to control their behaviour inside of the Box!
     widget.hasChildren = true
     widget.valChildren.add(BoxChild[Widget](
       widget: child,

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -339,8 +339,7 @@ renderable Label of BaseWidget:
   text: string ## The text of the Label to render
   xAlign: float = 0.5
   yAlign: float = 0.5
-  ellipsize: EllipsizeMode ## Determines whether to ellipsise the text in case space is insufficient to render all of it.
-  ## May be one of `EllipsizeNone`, `EllipsizeStart`, `EllipsizeMiddle` or `EllipsizeEnd`
+  ellipsize: EllipsizeMode ## Determines whether to ellipsise the text in case space is insufficient to render all of it. May be one of `EllipsizeNone`, `EllipsizeStart`, `EllipsizeMiddle` or `EllipsizeEnd`
   wrap: bool = false ## Enables/Disable wrapping of text.
   useMarkup: bool = false ## Determines whether to interpret the given text as Pango Markup or not.
   
@@ -430,9 +429,7 @@ type ButtonStyle* = enum
   ButtonCircular = "circular"
 
 renderable Button of BaseWidget:
-  style: set[ButtonStyle] ## Applies special styling to the button. 
-  ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
-  ## Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   child: Widget
   shortcut: string ## Keyboard shortcut
   
@@ -1339,7 +1336,7 @@ renderable MenuButton of BaseWidget:
   child: Widget
   popover: Widget
   
-  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   hooks:
     beforeBuild:
@@ -2120,7 +2117,7 @@ proc toGtk(resp: DialogResponse): cint =
 renderable DialogButton:
   text: string
   response: DialogResponse
-  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  style: set[ButtonStyle] ## Applies special styling to the button. May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`. Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   
   setter res: DialogResponseKind
 

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -430,7 +430,7 @@ type ButtonStyle* = enum
 renderable Button of BaseWidget:
   style: set[ButtonStyle] ## Applies special styling to the button. 
   ## May be one of `ButtonSuggested`, `ButtonDestructive`, `ButtonFlat`, `ButtonPill` or `ButtonCircular`.
-  ## Consult the ## [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
+  ## Consult the [GTK4 documentation](https://developer.gnome.org/hig/patterns/controls/buttons.html?highlight=button#button-styles) for guidance on what to use.
   child: Widget
   shortcut: string ## Keyboard shortcut
   
@@ -585,6 +585,10 @@ renderable HeaderBar of BaseWidget:
                    hAlign: AlignFill,
                    vAlign: AlignFill.}:
     ## Adds a custom title widget to the HeaderBar.
+    ## When expand is true, it grows to fill up the remaining space in the headerbar.
+    ## The hAlign and vAlign properties allow you to set the horizontal and vertical 
+    ## alignment of the child within its allocated area. They may be one of `AlignFill`, 
+    ## `AlignStart`, `AlignEnd` or `AlignCenter`.
     if widget.hasTitle:
       raise newException(ValueError, "Unable to add multiple title widgets to a HeaderBar.")
     widget.hasTitle = true

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -245,13 +245,14 @@ renderable Box of BaseWidget:
               vAlign: AlignFill.}:
     ## Adds a child to the Box.
     ## When expand is true, the child grows to fill up the remaining space in the Box.
-    ## The hAlign and vAlign properties allow you to set the alignment of the child
-    ## within its allocated area.
+    ## The hAlign and vAlign properties allow you to set the horizontal and vertical 
+    ## alignment of the child within its allocated area. They may be one of `AlignFill`, 
+    ## `AlignStart`, `AlignEnd` or `AlignCenter`.
     widget.hasChildren = true
     widget.valChildren.add(BoxChild[Widget](
       widget: child,
       expand: expand,
-      hAlign: hAlign,
+      hAlign: hAlign, 
       vAlign: vAlign
     ))
   

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -324,12 +324,15 @@ type EllipsizeMode* = enum
   EllipsizeNone, EllipsizeStart, EllipsizeMiddle, EllipsizeEnd
 
 renderable Label of BaseWidget:
-  text: string
+  ## The default widget to display text.
+  ## Supports rendering [Pango Markup](https://docs.gtk.org/Pango/pango_markup.html#pango-markup) 
+  ## if `useMarkup` is enabled.
+  text: string ## The text of the Label to render
   xAlign: float = 0.5
   yAlign: float = 0.5
-  ellipsize: EllipsizeMode
-  wrap: bool = false
-  useMarkup: bool = false
+  ellipsize: EllipsizeMode ## Determines whether to ellipsise the text in case space is insufficient to render all of it.
+  wrap: bool = false ## Enables/Disable wrapping of text.
+  useMarkup: bool = false ## Determines whether to interpret the given text as Pango Markup or not.
   
   style: set[LabelStyle]
   


### PR DESCRIPTION
This is an in-between PR.
I'll likely make further PR's under this ticket-number, but this way you can have several smaller/medium sized PRs that improve things incrementally rather than one bombastic ones.

Basically all of this PR is just adding a bunch of doc-comments everywhere.
Either to explain what a value stands for, repeat an explanation of a value that has already been written but for a different Widget (vAlign and hAlign have that issue), listing the possible enum-values to make it quicker to find the available values etc.