### PR TITLE
Fix `gorge` breaking builds

### DIFF
--- a/owlkettle/cairo.nim
+++ b/owlkettle/cairo.nim
@@ -77,7 +77,8 @@ type
 
 proc `==`(a, b: CairoStatus): bool {.borrow.}
 
-{.passl: gorge("pkg-config --libs cairo").}
+import std/strutils as strutils
+{.passl: strutils.strip(gorge("pkg-config --libs cairo")) .}
 
 {.push importc, cdecl.}
 proc cairo_create(surface: CairoSurface): CairoContext

--- a/owlkettle/gtk.nim
+++ b/owlkettle/gtk.nim
@@ -24,7 +24,8 @@
 
 import std/[os]
 
-{.passl: gorge("pkg-config --libs gtk4").}
+import std/strutils as strutils
+{.passl: strutils.strip(gorge("pkg-config --libs gtk4")).}
 
 type cbool* = cint
 


### PR DESCRIPTION
Basically, I did just two adjusts that permits me compile any `owlkettle` in Windows system.
I don't know if this problem exists in others OSes, but while using `Msys2` I had some problems to compile the example application.

- You can see #53 to more information.

But, in summary, `gorge` returns a multiline string that needs to be stripped.

> Side note: I imported `strutils` using `as` parameter to avoid any variable conflict with the rest of the implementation...