### PR TITLE
Add Windows's GTK install instruction and the official documentation link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To enable libadwaita, import `owlkettle/adw` and change the last line to `adw.br
 ## Installation
 
 Owlkettle requires GTK 4 to be installed on your system.
-You can install it by running `dnf install gtk4-devel libadwaita-devel` on Fedora or `apt install libgtk-4-dev libadwaita-1-dev` on Ubuntu.
+You can install it by running `dnf install gtk4-devel libadwaita-devel` on Fedora or `apt install libgtk-4-dev libadwaita-1-dev` on Ubuntu or `pacman -S mingw-w64-x86_64-gtk4` on Windows' Msys.
 
 ```bash
 $ nimble install owlkettle

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To enable libadwaita, import `owlkettle/adw` and change the last line to `adw.br
 ## Installation
 
 Owlkettle requires GTK 4 to be installed on your system.
-You can install it by running `dnf install gtk4-devel libadwaita-devel` on Fedora or `apt install libgtk-4-dev libadwaita-1-dev` on Ubuntu or `pacman -S mingw-w64-x86_64-gtk4` on Windows' Msys.
+You can install it by running `dnf install gtk4-devel libadwaita-devel` on Fedora or `apt install libgtk-4-dev libadwaita-1-dev` on Ubuntu or `pacman -S mingw-w64-x86_64-gtk4` on Windows' Msys. Or see [the official guide](https://www.gtk.org/docs/installations/) to more instructions.
 
 ```bash
 $ nimble install owlkettle


### PR DESCRIPTION
Well, this PR is not the most important thing in the world, but can be helpful for some users.

I just added a simple instruction to install GTK lib in Windows' Msys2 ecosystem and a hyperlink to the official installation instructions. 🙂 

I hope you like this.