### PR TITLE
Add Gtk.Window::fullscreened

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -49,7 +49,7 @@ renderable Window of BaseWindow
 
 - All fields from [BaseWindow](#BaseWindow)
 - `title: string`
-- `fullscreened: bool` Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively.
+- `fullscreened: bool` Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively. Either operation is asynchronous, which means you will need to connect to the `::notify` signal in order to know whether the operation was successful (it could fail if, for instance, a window manager refuses to respond to the signal).
 - `titlebar: Widget` Custom widget set as the titlebar of the window
 - `child: Widget`
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -49,6 +49,7 @@ renderable Window of BaseWindow
 
 - All fields from [BaseWindow](#BaseWindow)
 - `title: string`
+- `fullscreened: bool` Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively.
 - `titlebar: Widget` Custom widget set as the titlebar of the window
 - `child: Widget`
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -49,7 +49,7 @@ renderable Window of BaseWindow
 
 - All fields from [BaseWindow](#BaseWindow)
 - `title: string`
-- `fullscreened: bool` Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively. Either operation is asynchronous, which means you will need to connect to the `::notify` signal in order to know whether the operation was successful (it could fail if, for instance, a window manager refuses to respond to the signal).
+- `fullscreened: bool`
 - `titlebar: Widget` Custom widget set as the titlebar of the window
 - `child: Widget`
 

--- a/owlkettle/gtk.nim
+++ b/owlkettle/gtk.nim
@@ -554,6 +554,8 @@ proc gtk_window_set_modal*(window: GtkWidget, modal: cbool)
 proc gtk_window_set_focus*(window, focus: GtkWidget)
 proc gtk_window_set_child*(window, child: GtkWidget)
 proc gtk_window_present*(window: GtkWidget)
+proc gtk_window_fullscreen*(window: GtkWidget)
+proc gtk_window_unfullscreen*(window: GtkWidget)
 proc gtk_window_get_toplevels*(): GListModel
 proc gtk_window_close*(window: GtkWidget)
 proc gtk_window_destroy*(window: GtkWidget)

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -144,10 +144,8 @@ renderable Window of BaseWindow:
   hooks fullscreened:
     property:
       if state.fullscreened:
-        echo "fullscreening"
         gtk_window_fullscreen(state.internalWidget)
       else:
-        echo "unfullscreening"
         gtk_window_unfullscreen(state.internalWidget)
   
   hooks titlebar:

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -128,16 +128,13 @@ renderable BaseWindow of BaseWidget:
 
 renderable Window of BaseWindow:
   title: string
-  fullscreened: bool ## Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively. Either operation is asynchronous, which means you will need to connect to the `::notify` signal in order to know whether the operation was successful (it could fail if, for instance, a window manager refuses to respond to the signal).
+  fullscreened: bool
   titlebar: Widget ## Custom widget set as the titlebar of the window
   child: Widget
   
   hooks:
     beforeBuild:
       state.internalWidget = gtk_window_new(GTK_WINDOW_TOPLEVEL)
-    afterBuild:
-      if state.fullscreened:
-        gtk_window_fullscreen(state.internalWidget)
   
   hooks title:
     property:

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -144,8 +144,10 @@ renderable Window of BaseWindow:
   hooks fullscreened:
     property:
       if state.fullscreened:
+        echo "fullscreening"
         gtk_window_fullscreen(state.internalWidget)
       else:
+        echo "unfullscreening"
         gtk_window_unfullscreen(state.internalWidget)
   
   hooks titlebar:

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -135,6 +135,9 @@ renderable Window of BaseWindow:
   hooks:
     beforeBuild:
       state.internalWidget = gtk_window_new(GTK_WINDOW_TOPLEVEL)
+    afterBuild:
+      if state.fullscreened:
+        gtk_window_fullscreen(state.internalWidget)
   
   hooks title:
     property:

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -128,6 +128,7 @@ renderable BaseWindow of BaseWidget:
 
 renderable Window of BaseWindow:
   title: string
+  fullscreened: bool ## Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively.
   titlebar: Widget ## Custom widget set as the titlebar of the window
   child: Widget
   
@@ -139,6 +140,13 @@ renderable Window of BaseWindow:
     property:
       if state.titlebar.isNil:
         gtk_window_set_title(state.internalWidget, state.title.cstring)
+
+  hooks fullscreened:
+    property:
+      if state.fullscreened:
+        gtk_window_fullscreen(state.internalWidget)
+      else:
+        gtk_window_unfullscreen(state.internalWidget)
   
   hooks titlebar:
     (build, update):

--- a/owlkettle/widgets.nim
+++ b/owlkettle/widgets.nim
@@ -128,7 +128,7 @@ renderable BaseWindow of BaseWidget:
 
 renderable Window of BaseWindow:
   title: string
-  fullscreened: bool ## Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively.
+  fullscreened: bool ## Whether or not the window is fullscreened; setting this property is equivalent to calling `gtk_window_fullscreen` and `gtk_window_unfullscreen` for values of `true` and `false`, respectively. Either operation is asynchronous, which means you will need to connect to the `::notify` signal in order to know whether the operation was successful (it could fail if, for instance, a window manager refuses to respond to the signal).
   titlebar: Widget ## Custom widget set as the titlebar of the window
   child: Widget
   


### PR DESCRIPTION
This adds the [fullscreened](https://docs.gtk.org/gtk4/property.Window.fullscreened.html) property to `Window`. It's implemented using `gtk_window_fullscren` and `gtk_window_unfullscreen`.