### PR TITLE
Refactor playground to not use toListFormField + Remove unused imports from examples

### DIFF
--- a/examples/widgets/action_bar.nim
+++ b/examples/widgets/action_bar.nim
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import std/[sequtils]
 import owlkettle, owlkettle/[dataentries, playground, adw]
 
 viewable App:

--- a/examples/widgets/editable_label.nim
+++ b/examples/widgets/editable_label.nim
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import std/[sequtils]
 import owlkettle, owlkettle/[dataentries, playground, adw]
 
 viewable App:

--- a/examples/widgets/fixed.nim
+++ b/examples/widgets/fixed.nim
@@ -21,7 +21,7 @@
 # SOFTWARE
 
 import std/random
-import owlkettle, owlkettle/[adw, dataentries]
+import owlkettle, owlkettle/[adw]
 
 type FixedItem = ref object
   name: string

--- a/examples/widgets/picture.nim
+++ b/examples/widgets/picture.nim
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import std/[asyncfutures]
 import owlkettle, owlkettle/[playground, adw]
 
 const APP_NAME = "Image Example"

--- a/examples/widgets/picture.nim
+++ b/examples/widgets/picture.nim
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import std/asyncfutures
 import owlkettle, owlkettle/[playground, adw]
 
 const APP_NAME = "Image Example"

--- a/examples/widgets/scale.nim
+++ b/examples/widgets/scale.nim
@@ -44,29 +44,30 @@ method view(app: AppState): Widget =
   result = gui:
     Window():
       title = "Scale Example"
-      defaultSize = (800, 600)
+      defaultSize = (800, 150)
       HeaderBar() {.addTitlebar.}:
         insert(app.toAutoFormMenu()) {.addRight.}
       
-      Scale:
-        min = app.min
-        max = app.max
-        value = app.value
-        marks = app.marks
-        inverted = app.inverted
-        showValue = app.showValue
-        stepSize = app.stepSize
-        pageSize = app.pageSize
-        orient = app.orient
-        showFillLevel = app.showFillLevel
-        precision = app.precision
-        valuePosition = app.valuePosition
-        sensitive = app.sensitive
-        tooltip = app.tooltip
-        sizeRequest = app.sizeRequest
-        
-        proc valueChanged(newValue: float64) =
-          app.value = newValue
-          echo "New value from Scale is ", $newValue
+      Box(orient = OrientY):
+        Scale {.expand: false.}:
+          min = app.min
+          max = app.max
+          value = app.value
+          marks = app.marks
+          inverted = app.inverted
+          showValue = app.showValue
+          stepSize = app.stepSize
+          pageSize = app.pageSize
+          orient = app.orient
+          showFillLevel = app.showFillLevel
+          precision = app.precision
+          valuePosition = app.valuePosition
+          sensitive = app.sensitive
+          tooltip = app.tooltip
+          sizeRequest = app.sizeRequest
+          
+          proc valueChanged(newValue: float64) =
+            app.value = newValue
+            echo "New value from Scale is ", $newValue
 
 adw.brew(gui(App()))

--- a/owlkettle.nim
+++ b/owlkettle.nim
@@ -134,42 +134,6 @@ proc remove*(event: EventDescriptor) =
   if g_source_remove(cuint(event)) == 0:
     raise newException(IoError, "Unable to remove " & $event)
 
-proc open*(app: Viewable, widget: Widget): tuple[res: DialogResponse, state: WidgetState] =
-  let
-    state = widget.build()
-    dialogState = state.unwrapRenderable()
-    window = app.unwrapInternalWidget()
-    dialog = state.unwrapInternalWidget()
-  gtk_window_set_transient_for(dialog, window)
-  gtk_window_set_modal(dialog, cbool(bool(true)))
-  gtk_window_present(dialog)
-  
-  proc destroy(dialog: GtkWidget, closed: ptr bool) {.cdecl.} =
-    closed[] = true
-  
-  var closed = false
-  discard g_signal_connect(dialog, "destroy", destroy, closed.addr)
-  
-  if dialogState of DialogState or dialogState of BuiltinDialogState:
-    proc response(dialog: GtkWidget, responseId: cint, res: ptr cint) {.cdecl.} =
-      res[] = responseId
-    
-    var res = low(cint)
-    discard g_signal_connect(dialog, "response", response, res.addr)
-    while res == low(cint):
-      discard g_main_context_iteration(nil.GMainContext, cbool(ord(true)))
-    
-    state.read()
-    if not closed:
-      gtk_window_destroy(dialog)
-    result = (toDialogResponse(res), state)
-  else:
-    while not closed:
-      discard g_main_context_iteration(nil.GMainContext, cbool(ord(true)))
-    
-    state.read()
-    result = (DialogResponse(), state)
-
 proc respond*(state: WidgetState, response: DialogResponse) =
   let
     widget = state.unwrapInternalWidget()

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -29,7 +29,7 @@ import ./widgetdef
 import ./widgets
 
 proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget =
-  ## Provides a form field for all number times in SomeNumber
+  ## Provides a form field for all number types in SomeNumber
   return gui:
     ActionRow:
       title = fieldName
@@ -40,11 +40,8 @@ proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Wid
         proc changed(value: float) =
           field[] = type(field[])(value)
 
-type Range = concept r # Necessary as there is no range typeclass *for parameters*. So `field: ptr range` is not a valid parameter.
-  r is range
-
 proc toFormField(state: Viewable, field: ptr Range, fieldName: string): Widget =
-  ## Provides a form field for any range
+  ## Provides a form field for all range types
   return gui:
     ActionRow:
       title = fieldName
@@ -56,7 +53,7 @@ proc toFormField(state: Viewable, field: ptr Range, fieldName: string): Widget =
           field[] = value
 
 proc toFormField(state: Viewable, field: ptr string, fieldName: string): Widget =
-  ## Provides a form field for string
+  ## Provides a form field for strings
   return gui:
     ActionRow:
       title = fieldName
@@ -66,7 +63,7 @@ proc toFormField(state: Viewable, field: ptr string, fieldName: string): Widget 
           field[] = text
 
 proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget =
-  ## Provides a form field for bool
+  ## Provides a form field for booleans
   return gui:
     ActionRow:
       title = fieldName
@@ -76,31 +73,8 @@ proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget =
           proc changed(newVal: bool) =
             field[] = newVal
 
-proc toFormField(state: Viewable, field: ptr[auto], fieldName: string): Widget =
-  ## Provides a dummy field as a fallback for any type without a `toFormField`.
-  const typeName: string = $field[].type
-  return gui:
-    ActionRow:
-      title = fieldName
-      Label():
-        text = fmt"Override `toFormField` for '{typeName}'"
-        tooltip = fmt"""
-          The type '{typeName}' must implement a `toFormField` proc:
-          `toFormField(
-            state: Viewable, 
-            field: ptr {typeName}
-            fieldName: string, 
-          ): Widget`
-          state: The <Widget>State
-          field: The field's value to assign to/get the value from
-          fieldName: The name of the field on `state` for which the current form field is being generated
-          
-          Implementing the proc will override this dummy Widget.
-          See the playground module for examples.
-        """
-
 proc toFormField(state: Viewable, field: ptr[enum] , fieldName: string): Widget =
-  ## Provides a form field for enums
+  ## Provides a form field for all enum types
   let options: seq[string] = type(field[]).items.toSeq().mapIt($it)
   return gui:
     ComboRow:
@@ -136,7 +110,7 @@ method view (state: DateDialogState): Widget =
             state.date = date
 
 proc toFormField(state: Viewable, field: ptr DateTime, fieldName: string): Widget =
-  ## Provides a form field for DateTime
+  ## Provides a form field for DateTimes
   return gui:
     ActionRow:
       title = fieldName
@@ -170,7 +144,7 @@ proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string
           field[][1] = value.int
 
 proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widget =
-  ## Provides a form to display a single entry of type `ScaleMark` in a list of `ScaleMark` entries.
+  ## Provides a form field for the type ScaleMark
   return gui:
     ActionRow:
       title = fieldName
@@ -189,8 +163,7 @@ proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widg
           field[].position = enumIndex.ScalePosition
 
 proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widget =
-  ## Provides a form field for any field on `state` with a seq type.
-  ## Displays a dummy widget if there is no `toListFormField` implementation for type T.
+  ## Provides a form field for any seq type
   let formFields = collect(newSeq):
     for index, value in field[]:
       toFormField(state, field[][index].addr, fieldName)

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -32,7 +32,7 @@ type Range = concept r # Necessary as there is no range typeclass *for parameter
   r is range
 
 proc selfAssign[T](v: var T) = v = v
-proc isObjectVariant(Obj: typedesc[object]): bool =
+proc isObjectVariantType(Obj: typedesc[object]): bool =
   ## Checks if a given typedesc is of an object variant
   ## by checking if you can assign to a field. This is a 
   ## compile-time error when doing this with the fieldPairs iterator
@@ -44,9 +44,11 @@ proc isObjectVariant(Obj: typedesc[object]): bool =
   
   return false
     
-type ObjectVariant = concept type V
-  ## A concept covering all object variant types
-  isObjectVariant(V)
+type ObjectVariantType = concept type V
+  ## A concept covering all object variant types. 
+  ## This concept is **not** intended for use with object variant **instances**,
+  ## as its implementation relies on type.
+  isObjectVariantType(V)
 
 # Forward Declarations so order of procs below doesn't matter
 proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget
@@ -59,7 +61,7 @@ proc toFormField(state: Viewable, field: ptr[distinct], fieldName: string): Widg
 proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widget
 proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widget
-proc toFormField(state: Viewable, field: ptr ObjectVariant, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr ObjectVariantType, fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr auto, fieldName: string): Widget
 
 proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget =
@@ -261,7 +263,7 @@ proc toPlaceHolderFormField(state: Viewable, field: ptr[auto], fieldName: string
           See the playground module for examples.
         """
 
-proc toFormField(state: Viewable, field: ptr ObjectVariant, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr ObjectVariantType, fieldName: string): Widget =
   ## Provides a form field for any object variant type
   return state.toPlaceHolderFormField(field, fieldName)
 

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -38,6 +38,7 @@ proc toFormField(state: Viewable, field: ptr string, fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr[enum], fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr DateTime, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr[distinct], fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string): Widget
 proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widget
 proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widget
@@ -138,6 +139,13 @@ proc toFormField(state: Viewable, field: ptr DateTime, fieldName: string): Widge
           let (res, dialogState) = state.open(gui(DateDialog()))
           if res.kind == DialogAccept:
             field[] = DateDialogState(dialogState).date
+
+
+proc toFormField(state: Viewable, field: ptr[distinct], fieldName: string): Widget =
+  ## Provides a form field for any distinct type. 
+  ## The form field provided is the same that the base-type of the distinct type would have.
+  let baseField = field[].distinctBase.addr
+  toFormField(state, baseField, fieldName)
 
 proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string): Widget =
   ## Provides a form field for the tuple type of sizeRequest

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -88,7 +88,7 @@ proc toFormField(state: auto, field: ptr auto, fieldName: static string): Widget
           See the playground module for examples.
         """
 
-proc toFormField(state: auto, field: ptr enum, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr[enum] , fieldName: static string): Widget =
   ## Provides a form field for enums
   let options: seq[string] = type(field[]).items.toSeq().mapIt($it)
   return gui:

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -28,6 +28,22 @@ import ./guidsl
 import ./widgetdef
 import ./widgets
 
+type Range = concept r # Necessary as there is no range typeclass *for parameters*. So `field: ptr range` is not a valid parameter.
+  r is range
+
+# Forward Declarations so order of procs below doesn't matter
+proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr Range, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr string, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr[enum], fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr DateTime, fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widget
+proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widget
+proc toFormField(state: Viewable, field: ptr auto, fieldName: string): Widget
+
+
 proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget =
   ## Provides a form field for all number types in SomeNumber
   return gui:

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -199,8 +199,13 @@ proc toFormField[T](state: auto, field: ptr seq[T], fieldName: string): Widget =
       title = fieldName
       
       for index, formField in formFields:
-        insert(formField){.addRow.}:
-          Button(text = "lala") {.addSuffix.}
+        Box(orient = OrientX) {.addRow.}:
+          insert(formField)
+          Button() {.expand: false.}:
+            icon = "user-trash-symbolic"
+            style = [ButtonDestructive]
+            proc clicked() =
+              field[].delete(index) 
       
       ListBoxRow {.addRow.}:
         Button:

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -29,7 +29,7 @@ import ./widgetdef
 import ./widgets
 
 # Default `toFormField` implementations
-proc toFormField(state: auto, field: ptr SomeNumber, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget =
   ## Provides a form field for all number times in SomeNumber
   return gui:
     ActionRow:
@@ -42,7 +42,7 @@ proc toFormField(state: auto, field: ptr SomeNumber, fieldName: string): Widget 
           field[] = type(field[])(value)
 
 # Default `toFormField` implementations
-proc toFormField(state: auto, field: ptr range[0.0..1.0], fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr range[0.0..1.0], fieldName: string): Widget =
   ## Provides a form field for a range of float numbers between 0.0 and 1.0
   return gui:
     ActionRow:
@@ -54,7 +54,7 @@ proc toFormField(state: auto, field: ptr range[0.0..1.0], fieldName: string): Wi
         proc changed(value: float) =
           field[] = value
 
-proc toFormField(state: auto, field: ptr string, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr string, fieldName: string): Widget =
   ## Provides a form field for string
   return gui:
     ActionRow:
@@ -64,7 +64,7 @@ proc toFormField(state: auto, field: ptr string, fieldName: string): Widget =
         proc changed(text: string) =
           field[] = text
 
-proc toFormField(state: auto, field: ptr bool, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget =
   ## Provides a form field for bool
   return gui:
     ActionRow:
@@ -75,7 +75,7 @@ proc toFormField(state: auto, field: ptr bool, fieldName: string): Widget =
           proc changed(newVal: bool) =
             field[] = newVal
 
-proc toFormField(state: auto, field: ptr auto, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr auto, fieldName: string): Widget =
   ## Provides a dummy field as a fallback for any type without a `toFormField`.
   const typeName: string = $field[].type
   return gui:
@@ -86,7 +86,7 @@ proc toFormField(state: auto, field: ptr auto, fieldName: string): Widget =
         tooltip = fmt"""
           The type '{typeName}' must implement a `toFormField` proc:
           `toFormField(
-            state: auto, 
+            state: Viewable, 
             field: ptr {typeName}
             fieldName: string, 
           ): Widget`
@@ -98,7 +98,7 @@ proc toFormField(state: auto, field: ptr auto, fieldName: string): Widget =
           See the playground module for examples.
         """
 
-proc toFormField(state: auto, field: ptr[enum] , fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr[enum] , fieldName: string): Widget =
   ## Provides a form field for enums
   let options: seq[string] = type(field[]).items.toSeq().mapIt($it)
   return gui:
@@ -134,7 +134,7 @@ method view (state: DateDialogState): Widget =
           proc select(date: DateTime) =
             state.date = date
 
-proc toFormField(state: auto, field: ptr DateTime, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr DateTime, fieldName: string): Widget =
   ## Provides a form field for DateTime
   return gui:
     ActionRow:
@@ -148,7 +148,7 @@ proc toFormField(state: auto, field: ptr DateTime, fieldName: string): Widget =
           if res.kind == DialogAccept:
             field[] = DateDialogState(dialogState).date
 
-proc toFormField(state: auto, field: ptr tuple[x, y: int], fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr tuple[x, y: int], fieldName: string): Widget =
   ## Provides a form field for the tuple type of sizeRequest
   let tup = field[]
   return gui:
@@ -168,7 +168,7 @@ proc toFormField(state: auto, field: ptr tuple[x, y: int], fieldName: string): W
         proc changed(value: float) =
           field[][1] = value.int
 
-proc toFormField(state: auto, field: ptr ScaleMark, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr ScaleMark, fieldName: string): Widget =
   ## Provides a form to display a single entry of type `ScaleMark` in a list of `ScaleMark` entries.
   return gui:
     ActionRow:
@@ -187,7 +187,7 @@ proc toFormField(state: auto, field: ptr ScaleMark, fieldName: string): Widget =
         proc select(enumIndex: int) =
           field[].position = enumIndex.ScalePosition
 
-proc toFormField[T](state: auto, field: ptr seq[T], fieldName: string): Widget =
+proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widget =
   ## Provides a form field for any field on `state` with a seq type.
   ## Displays a dummy widget if there is no `toListFormField` implementation for type T.
   let formFields = collect(newSeq):

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -166,7 +166,7 @@ proc toFormField[T](state: Viewable, field: ptr seq[T], fieldName: string): Widg
   ## Provides a form field for any seq type
   let formFields = collect(newSeq):
     for index, value in field[]:
-      toFormField(state, field[][index].addr, fieldName)
+      toFormField(state, field[][index].addr, fmt"{fieldName} {index}")
       
   return gui:
     ExpanderRow:

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -28,11 +28,11 @@ import ./guidsl
 import ./widgetdef
 import ./widgets
 
-macro getField*(someType: untyped, fieldName: static string): untyped =
+macro getField*(someType: untyped, fieldName: string): untyped =
   nnkDotExpr.newTree(someType, ident(fieldName))
 
 # Default `toFormField` implementations
-proc toFormField(state: auto, field: ptr SomeNumber, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr SomeNumber, fieldName: string): Widget =
   ## Provides a form field for all number times in SomeNumber
   return gui:
     ActionRow:
@@ -44,7 +44,7 @@ proc toFormField(state: auto, field: ptr SomeNumber, fieldName: static string): 
         proc changed(value: float) =
           field[] = type(field[])(value)
 
-proc toFormField(state: auto, field: ptr string, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr string, fieldName: string): Widget =
   ## Provides a form field for string
   return gui:
     ActionRow:
@@ -54,7 +54,7 @@ proc toFormField(state: auto, field: ptr string, fieldName: static string): Widg
         proc changed(text: string) =
           field[] = text
 
-proc toFormField(state: auto, field: ptr bool, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr bool, fieldName: string): Widget =
   ## Provides a form field for bool
   return gui:
     ActionRow:
@@ -65,7 +65,7 @@ proc toFormField(state: auto, field: ptr bool, fieldName: static string): Widget
           proc changed(newVal: bool) =
             field[] = newVal
 
-proc toFormField(state: auto, field: ptr auto, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr auto, fieldName: string): Widget =
   ## Provides a dummy field as a fallback for any type without a `toFormField`.
   const typeName: string = $field[].type
   return gui:
@@ -78,7 +78,7 @@ proc toFormField(state: auto, field: ptr auto, fieldName: static string): Widget
           `toFormField(
             state: auto, 
             field: ptr {typeName}
-            fieldName: static string, 
+            fieldName: string, 
           ): Widget`
           state: The <Widget>State
           field: The field's value to assign to/get the value from
@@ -88,7 +88,7 @@ proc toFormField(state: auto, field: ptr auto, fieldName: static string): Widget
           See the playground module for examples.
         """
 
-proc toFormField(state: auto, field: ptr[enum] , fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr[enum] , fieldName: string): Widget =
   ## Provides a form field for enums
   let options: seq[string] = type(field[]).items.toSeq().mapIt($it)
   return gui:
@@ -124,7 +124,7 @@ method view (state: DateDialogState): Widget =
           proc select(date: DateTime) =
             state.date = date
 
-proc toFormField(state: auto, field: ptr DateTime, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr DateTime, fieldName: string): Widget =
   ## Provides a form field for DateTime
   return gui:
     ActionRow:
@@ -138,7 +138,7 @@ proc toFormField(state: auto, field: ptr DateTime, fieldName: static string): Wi
           if res.kind == DialogAccept:
             field[] = DateDialogState(dialogState).date
 
-proc toFormField(state: auto, field: ptr tuple[x, y: int], fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr tuple[x, y: int], fieldName: string): Widget =
   ## Provides a form field for the tuple type of sizeRequest
   let tup = field[]
   return gui:
@@ -158,7 +158,7 @@ proc toFormField(state: auto, field: ptr tuple[x, y: int], fieldName: static str
         proc changed(value: float) =
           field[][1] = value.int
 
-proc toFormField(state: auto, field: ptr ScaleMark, fieldName: static string): Widget =
+proc toFormField(state: auto, field: ptr ScaleMark, fieldName: string): Widget =
   ## Provides a form to display a single entry of type `ScaleMark` in a list of `ScaleMark` entries.
   return gui:
     ActionRow:
@@ -177,7 +177,7 @@ proc toFormField(state: auto, field: ptr ScaleMark, fieldName: static string): W
         proc select(enumIndex: int) =
           field[].position = enumIndex.ScalePosition
 
-proc toFormField[T](state: auto, field: ptr seq[T], fieldName: static string): Widget =
+proc toFormField[T](state: auto, field: ptr seq[T], fieldName: string): Widget =
   ## Provides a form field for any field on `state` with a seq type.
   ## Displays a dummy widget if there is no `toListFormField` implementation for type T.
   let formFields = collect(newSeq):

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -28,7 +28,6 @@ import ./guidsl
 import ./widgetdef
 import ./widgets
 
-# Default `toFormField` implementations
 proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Widget =
   ## Provides a form field for all number times in SomeNumber
   return gui:
@@ -41,9 +40,11 @@ proc toFormField(state: Viewable, field: ptr SomeNumber, fieldName: string): Wid
         proc changed(value: float) =
           field[] = type(field[])(value)
 
-# Default `toFormField` implementations
-proc toFormField(state: Viewable, field: ptr range[0.0..1.0], fieldName: string): Widget =
-  ## Provides a form field for a range of float numbers between 0.0 and 1.0
+type Range = concept r # Necessary as there is no range typeclass *for parameters*. So `field: ptr range` is not a valid parameter.
+  r is range
+
+proc toFormField(state: Viewable, field: ptr Range, fieldName: string): Widget =
+  ## Provides a form field for any range
   return gui:
     ActionRow:
       title = fieldName
@@ -75,7 +76,7 @@ proc toFormField(state: Viewable, field: ptr bool, fieldName: string): Widget =
           proc changed(newVal: bool) =
             field[] = newVal
 
-proc toFormField(state: Viewable, field: ptr auto, fieldName: string): Widget =
+proc toFormField(state: Viewable, field: ptr[auto], fieldName: string): Widget =
   ## Provides a dummy field as a fallback for any type without a `toFormField`.
   const typeName: string = $field[].type
   return gui:

--- a/owlkettle/playground.nim
+++ b/owlkettle/playground.nim
@@ -28,9 +28,6 @@ import ./guidsl
 import ./widgetdef
 import ./widgets
 
-macro getField*(someType: untyped, fieldName: string): untyped =
-  nnkDotExpr.newTree(someType, ident(fieldName))
-
 # Default `toFormField` implementations
 proc toFormField(state: auto, field: ptr SomeNumber, fieldName: string): Widget =
   ## Provides a form field for all number times in SomeNumber
@@ -43,6 +40,19 @@ proc toFormField(state: auto, field: ptr SomeNumber, fieldName: string): Widget 
         maxWidth = 8
         proc changed(value: float) =
           field[] = type(field[])(value)
+
+# Default `toFormField` implementations
+proc toFormField(state: auto, field: ptr range[0.0..1.0], fieldName: string): Widget =
+  ## Provides a form field for a range of float numbers between 0.0 and 1.0
+  return gui:
+    ActionRow:
+      title = fieldName
+      FormulaEntry() {.addSuffix.}:
+        value = field[]
+        xAlign = 1.0
+        maxWidth = 8
+        proc changed(value: float) =
+          field[] = value
 
 proc toFormField(state: auto, field: ptr string, fieldName: string): Widget =
   ## Provides a form field for string
@@ -189,7 +199,8 @@ proc toFormField[T](state: auto, field: ptr seq[T], fieldName: string): Widget =
       title = fieldName
       
       for index, formField in formFields:
-        insert(formField){.addRow.}
+        insert(formField){.addRow.}:
+          Button(text = "lala") {.addSuffix.}
       
       ListBoxRow {.addRow.}:
         Button:


### PR DESCRIPTION
This takes care of the refactoring we had discussed for playground and for which I had written up a reminder in #106 : https://github.com/can-lehmann/owlkettle/discussions/106#discussioncomment-7350315

Does exactly what the heading states.

This PR should be *mostly* independent from the other 10. I distantly recall one of the other 10 requiring me to implement another toListFormField proc, but I can adjust that.

While I was at it I also noticed a couple examples importing modules they no longer need, so just cleared that up to remove those warning messages.

I also did a slight change to the Scale example, as it really does not look pretty when you add a mark with position top/right to it if it takes up the entire Window. So I put it in a Box() widget with expand: false.