### PR TITLE
Add simple instructions to set up pkg-config for MSYS2

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ and the `pkg-config` as well.
 
 There are 2 noteworthy toolchain provided by the MSYS2:
 
-A) `CLANG64`: the recommended one for Nim:
+A) `CLANG64`: the recommended one for Nim
 
 ```bash
 $ pacman -Syu mingw-w64-clang-x86_64-toolchain

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,6 @@ Depending on your operating system, you can install GTK 4 using the following co
 
 - Fedora: `dnf install gtk4-devel libadwaita-devel`
 - Ubuntu: `apt install libgtk-4-dev libadwaita-1-dev`
-- Windows (Msys2): `pacman -S mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita`
 
 See [the GTK installation guide](https://www.gtk.org/docs/installations/) for more instructions.
 
@@ -15,30 +14,49 @@ We currently recommend installing the development version of owlkettle.
 $ nimble install owlkettle@#head
 ```
 
+## Properly setting up MSYS2 on Windows
+
+For the Windows OS you'll need the MSYS2 
+that you can install from their [official website](https://www.msys2.org/).
+
+Then, you'll need to use a toolchain with essential binaries as compilers, linkers 
+and the `pkg-config` as well.
+
+There are 2 noteworthy toolchain provided by the MSYS2:
+
+A) `CLANG64`: the recommended one for Nim:
+
+```bash
+$ pacman -Syu mingw-w64-clang-x86_64-toolchain
+```
+
+B) `UCRT64`: the recommended one by default for most projects
+
+```bash
+$ pacman -Syu mingw-w64-ucrt-x86_64-toolchain
+```
+
+Then add the GTK-4 and LibAdwaita to your environment.
+
+A) For `CLANG64`
+```bash
+$ pacman -S mingw-w64-clang-x86_64-gtk4 mingw-w64-clang-x86_64-libadwaita
+```
+
+B) For `UCRT64`
+
+```bash
+$ pacman -S mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-libadwaita
+```
+
+Feel free to ask questions about the MSYS2 setup in [How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
+
 ## Troubleshooting
 
 1. Ensure that `pkg-config` is installed and the output of the following command includes `-lgtk-4`.
   ```bash
   pkg-config --libs gtk4
   ```
-
-### Properly setting up MSYS2 on Windows
-
-If you want to make sure you have the `pkg-config` in your system, 
-you need to install your MSYS2's environment toolchain.
-
-The 2 noteworthy toolchain provided by the MSYS2 are:
-A) CLANG64: the recommended one for Nim
-B) UCRT64: the recommended one by default for most projects
-
-You can choose one of them by using these commands:
-
-```bash
-$ pacman -Syu mingw-w64-clang-x86_64-toolchain  # CLANG64
-$ pacman -Syu mingw-w64-ucrt-x86_64-toolchain   # UCRT64
-```
-
-Feel free to ask questions about the MSYS2 setup in [How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
 
 
 ## Known Incompatibilities

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ Depending on your operating system, you can install GTK 4 using the following co
 
 - Fedora: `dnf install gtk4-devel libadwaita-devel`
 - Ubuntu: `apt install libgtk-4-dev libadwaita-1-dev`
-- Windows (MSYS2): See information bellow
+- Windows (MSYS2): See instructions below
 
 See [the GTK installation guide](https://www.gtk.org/docs/installations/) for more instructions.
 
@@ -17,49 +17,44 @@ $ nimble install owlkettle@#head
 
 ## Properly setting up MSYS2 on Windows
 
-For the Windows OS you'll need the MSYS2 
-that you can install from their [official website](https://www.msys2.org/).
+You can install owlkettle on Windows using MSYS2.
+Install it from the [official website](https://www.msys2.org/).
 
-Then, you'll need to use a toolchain with essential binaries as compilers, linkers 
-and the `pkg-config` as well.
+You'll need to use a toolchain which includes essential binaries such as compilers, linkers and `pkg-config`.
+MSYS2 provides multiple environments, however `CLANG64` is the recommended one when working with Nim.
 
-There are some environments provided by the MSYS2,
-however the `CLANG64` is the recommended one 
-when working with Nim.
-
-So, let's start by installing its toolchain first with:
+So, let's start by installing its toolchain:
 
 ```bash
 $ pacman -Syu mingw-w64-clang-x86_64-toolchain
 ```
 
-Then add the GTK-4 and LibAdwaita to your environment.
+Then add GTK 4 and libadwaita to your environment.
 
 ```bash
 $ pacman -S mingw-w64-clang-x86_64-gtk4 mingw-w64-clang-x86_64-libadwaita
 ```
 
+If you encounter any issues, please check out the troubleshooting steps below.
+Feel free to ask questions about setting up owlkettle with MSYS2 in [this discussion](https://github.com/can-lehmann/owlkettle/discussions/144). 
+
 ### Other environments
 
-If you're a experienced MSYS2 user, 
-you can also install these packages 
-for other environments as the `MINGW64` and `UCRT64`.
+If you are an experienced MSYS2 user, you can also install these packages inside other environments.
 
-For the `MINGW64`:
+For the `MINGW64` environment:
 
 ```bash
 $ pacman -Syu mingw-w64-x86_64-toolchain
 $ pacman -S mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita
 ```
 
-For the `UCRT64`:
+For the `UCRT64` environment:
 
 ```bash
 $ pacman -Syu mingw-w64-ucrt-x86_64-toolchain
 $ pacman -S mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-libadwaita
 ```
-
-Feel free to ask questions about the MSYS2 setup in [How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,26 @@ $ nimble install owlkettle@#head
   pkg-config --libs gtk4
   ```
 
+### Properly setting up MSYS2 on Windows
+
+If you want to make sure you have the `pkg-config` in your system, 
+you need to install your MSYS2's environment toolchain.
+
+The `UCRT64` is the default environment you should use for any project, 
+but `CLANG` is the recommended one for Nim.
+
+Choose one of them:
+
+```bash
+$ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG
+$ pacman --sync --refresh --sysupgrade mingw-w64-ucrt-x86_64-toolchain   # UCRT
+```
+
+Moreover there is a discussion about this topic made by 
+[Michael Bradley](https://github.com/michaelsbradleyjr) and [RickBarretto](https://github.com/RickBarretto)
+where you can also discuss: 
+[How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
+
 ## Known Incompatibilities
 
 - When using Nim 1.6.12 or 1.6.14 with ARC/ORC, the Nim code generator produces invalid C code.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,8 +34,8 @@ B) UCRT64: the recommended one by default for most projects
 You can choose one of them by using these commands:
 
 ```bash
-$ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG64
-$ pacman --sync --refresh --sysupgrade mingw-w64-ucrt-x86_64-toolchain   # UCRT64
+$ pacman -Syu mingw-w64-clang-x86_64-toolchain  # CLANG64
+$ pacman -Syu mingw-w64-ucrt-x86_64-toolchain   # UCRT64
 ```
 
 Feel free to ask questions about the MSYS2 setup in [How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,30 +23,39 @@ that you can install from their [official website](https://www.msys2.org/).
 Then, you'll need to use a toolchain with essential binaries as compilers, linkers 
 and the `pkg-config` as well.
 
-There are 2 noteworthy toolchain provided by the MSYS2, choose one of them to install:
+There are some environments provided by the MSYS2,
+however the `CLANG64` is the recommended one 
+when working with Nim.
 
-A) `CLANG64`: the recommended one for Nim
+So, let's start by installing its toolchain first with:
 
 ```bash
 $ pacman -Syu mingw-w64-clang-x86_64-toolchain
 ```
 
-B) `UCRT64`: the recommended one by default for most projects
-
-```bash
-$ pacman -Syu mingw-w64-ucrt-x86_64-toolchain
-```
-
 Then add the GTK-4 and LibAdwaita to your environment.
 
-A) For `CLANG64`
 ```bash
 $ pacman -S mingw-w64-clang-x86_64-gtk4 mingw-w64-clang-x86_64-libadwaita
 ```
 
-B) For `UCRT64`
+### Other environments
+
+If you're a experienced MSYS2 user, 
+you can also install these packages 
+for other environments as the `MINGW64` and `UCRT64`.
+
+For the `MINGW64`:
 
 ```bash
+$ pacman -Syu mingw-w64-x86_64-toolchain
+$ pacman -S mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita
+```
+
+For the `UCRT64`:
+
+```bash
+$ pacman -Syu mingw-w64-ucrt-x86_64-toolchain
 $ pacman -S mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-libadwaita
 ```
 
@@ -58,7 +67,6 @@ Feel free to ask questions about the MSYS2 setup in [How to properly set-up your
   ```bash
   pkg-config --libs gtk4
   ```
-
 
 ## Known Incompatibilities
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ that you can install from their [official website](https://www.msys2.org/).
 Then, you'll need to use a toolchain with essential binaries as compilers, linkers 
 and the `pkg-config` as well.
 
-There are 2 noteworthy toolchain provided by the MSYS2:
+There are 2 noteworthy toolchain provided by the MSYS2, choose one of them to install:
 
 A) `CLANG64`: the recommended one for Nim
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,10 +27,11 @@ $ nimble install owlkettle@#head
 If you want to make sure you have the `pkg-config` in your system, 
 you need to install your MSYS2's environment toolchain.
 
-The `UCRT64` is the default environment you should use for any project, 
-but `CLANG64` is the recommended one for Nim.
+The 2 noteworthy toolchain provided by the MSYS2 are:
+A) CLANG64: the recommended one for Nim
+B) UCRT64: the recommended one by default for most projects
 
-Choose one of them:
+You can choose one of them by using these commands:
 
 ```bash
 $ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG64

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,7 @@ Depending on your operating system, you can install GTK 4 using the following co
 
 - Fedora: `dnf install gtk4-devel libadwaita-devel`
 - Ubuntu: `apt install libgtk-4-dev libadwaita-1-dev`
+- Windows (MSYS2): See information bellow
 
 See [the GTK installation guide](https://www.gtk.org/docs/installations/) for more instructions.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,13 +28,13 @@ If you want to make sure you have the `pkg-config` in your system,
 you need to install your MSYS2's environment toolchain.
 
 The `UCRT64` is the default environment you should use for any project, 
-but `CLANG` is the recommended one for Nim.
+but `CLANG64` is the recommended one for Nim.
 
 Choose one of them:
 
 ```bash
-$ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG
-$ pacman --sync --refresh --sysupgrade mingw-w64-ucrt-x86_64-toolchain   # UCRT
+$ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG64
+$ pacman --sync --refresh --sysupgrade mingw-w64-ucrt-x86_64-toolchain   # UCRT64
 ```
 
 Moreover there is a discussion about this topic made by 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,10 +37,8 @@ $ pacman --sync --refresh --sysupgrade mingw-w64-clang-x86_64-toolchain  # CLANG
 $ pacman --sync --refresh --sysupgrade mingw-w64-ucrt-x86_64-toolchain   # UCRT64
 ```
 
-Moreover there is a discussion about this topic made by 
-[Michael Bradley](https://github.com/michaelsbradleyjr) and [RickBarretto](https://github.com/RickBarretto)
-where you can also discuss: 
-[How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
+Feel free to ask questions about the MSYS2 setup in [How to properly set-up your MSYS2 #144](https://github.com/can-lehmann/owlkettle/discussions/144). 
+
 
 ## Known Incompatibilities
 


### PR DESCRIPTION
Adding simple instructions of how to install the UCRT and CLANG's toolchains for the MSYS2 on Windows.

Thanks to @michaelsbradleyjr.

**Additional links:**
- #144 