### PR TITLE
#148 Add custom signal emission utilities

### DIFF
--- a/owlkettle.nim
+++ b/owlkettle.nim
@@ -149,6 +149,8 @@ proc closeWindow*(state: WidgetState) =
 proc brew*(widget: Widget,
            icons: openArray[string] = [],
            darkTheme: bool = false,
+           startupEvents: openArray[StartUpEvent] = [],
+           shutdownEvents: openArray[ShutDownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   gtk_init()
   let state = setupApp(AppConfig(
@@ -163,6 +165,8 @@ proc brew*(id: string,
            widget: Widget,
            icons: openArray[string] = [],
            darkTheme: bool = false,
+           startupEvents: openArray[StartUpEvent] = [],
+           shutdownEvents: openArray[ShutDownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   var config = AppConfig(
     widget: widget,

--- a/owlkettle/adw.nim
+++ b/owlkettle/adw.nim
@@ -951,8 +951,8 @@ proc setupApp(config: AdwAppConfig): WidgetState =
 proc brew*(widget: Widget,
            icons: openArray[string] = [],
            colorScheme: ColorScheme = ColorSchemeDefault,
-           startupEvents: openArray[ApplicationEvent] = [],
-           shutdownEvents: openArray[ApplicationEvent] = [],
+           startupEvents: openArray[StartupEvent] = [],
+           shutdownEvents: openArray[ShutdownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   adw_init()
   let config = AdwAppConfig(
@@ -967,13 +967,14 @@ proc brew*(widget: Widget,
   let state = setupApp(config)
   config.execStartupEvents(state)
   runMainloop(state)
+  config.execShutdownEvents()
 
 proc brew*(id: string,
            widget: Widget,
            icons: openArray[string] = [],
            colorScheme: ColorScheme = ColorSchemeDefault,
-           startupEvents: openArray[ApplicationEvent] = [],
-           shutdownEvents: openArray[ApplicationEvent] = [],
+           startupEvents: openArray[StartupEvent] = [],
+           shutdownEvents: openArray[ShutdownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   var config = AdwAppConfig(
     widget: widget,
@@ -999,4 +1000,6 @@ proc brew*(id: string,
   
   discard g_signal_connect(app, "activate", activateCallback, config.addr)
   discard g_application_run(app)
+
+  config.execShutdownEvents()
 

--- a/owlkettle/adw.nim
+++ b/owlkettle/adw.nim
@@ -951,6 +951,8 @@ proc setupApp(config: AdwAppConfig): WidgetState =
 proc brew*(widget: Widget,
            icons: openArray[string] = [],
            colorScheme: ColorScheme = ColorSchemeDefault,
+           startupEvents: openArray[StartUpEvent] = [],
+           shutdownEvents: openArray[ShutDownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   adw_init()
   let state = setupApp(AdwAppConfig(
@@ -966,6 +968,8 @@ proc brew*(id: string,
            widget: Widget,
            icons: openArray[string] = [],
            colorScheme: ColorScheme = ColorSchemeDefault,
+           startupEvents: openArray[StartUpEvent] = [],
+           shutdownEvents: openArray[ShutDownEvent] = [],
            stylesheets: openArray[Stylesheet] = []) =
   var config = AdwAppConfig(
     widget: widget,

--- a/owlkettle/mainloop.nim
+++ b/owlkettle/mainloop.nim
@@ -71,10 +71,11 @@ type
     icons*: seq[string]
     darkTheme*: bool
     stylesheets*: seq[Stylesheet]
-    startupEvents*: seq[ApplicationEvent]
-    shutdownEvents*: seq[ApplicationEvent]
+    startupEvents*: seq[StartUpEvent]
+    shutdownEvents*: seq[ShutDownEvent]
   
-  ApplicationEvent* = proc(widget: Widget, state: WidgetState)
+  StartUpEvent* = proc(widget: Widget, state: WidgetState)
+  ShutDownEvent* = proc(widget: Widget)
   
 # proc registerEvents*(app: GApplication, config: AppConfig, state: WidgetState) =
 #   proc eventCallback(app: GApplication, data: ptr AppData) {.cdecl.} =
@@ -92,9 +93,9 @@ proc execStartupEvents*(config: AppConfig, state: WidgetState) =
   for event in config.startupEvents:
     event(config.widget, state)
     
-proc execShutdownEvents*(config: AppConfig, state: WidgetState) =
+proc execShutdownEvents*(config: AppConfig) =
   for event in config.shutdownEvents:
-    event(config.widget, state)
+    event(config.widget)
 
 proc setupApp*(config: AppConfig): WidgetState =
   if config.darkTheme:

--- a/owlkettle/mainloop.nim
+++ b/owlkettle/mainloop.nim
@@ -78,7 +78,7 @@ type
     startupEvents*: seq[ApplicationEvent]
     shutdownEvents*: seq[ApplicationEvent]
   
-  ApplicationEvent* = proc(state: WidgetState) {.nimcall.}
+  ApplicationEvent* = proc(state: WidgetState) {.closure.}
   
 proc execStartupEvents*(context: AppContext) =
   for event in context.startupEvents:

--- a/owlkettle/mainloop.nim
+++ b/owlkettle/mainloop.nim
@@ -71,31 +71,22 @@ type
     icons*: seq[string]
     darkTheme*: bool
     stylesheets*: seq[Stylesheet]
-    startupEvents*: seq[StartUpEvent]
-    shutdownEvents*: seq[ShutDownEvent]
   
-  StartUpEvent* = proc(widget: Widget, state: WidgetState)
-  ShutDownEvent* = proc(widget: Widget)
+  AppContext* = object
+    config*: AppConfig
+    state*: WidgetState
+    startupEvents*: seq[ApplicationEvent]
+    shutdownEvents*: seq[ApplicationEvent]
   
-# proc registerEvents*(app: GApplication, config: AppConfig, state: WidgetState) =
-#   proc eventCallback(app: GApplication, data: ptr AppData) {.cdecl.} =
-#     data[].event(data[].config, data[].event)
+  ApplicationEvent* = proc(state: WidgetState) {.nimcall.}
   
-#   for event in config.startupEvents:
-#     let eventData = AppEventData(config: config, state: state, event: event)
-#     discard g_signal_connect(app, "startup", eventCallback, eventData.addr)
-
-#   for event in config.shutdownEvents:
-#     let eventData = AppEventData(config: config, state: state, event: event)
-#     discard g_signal_connect(app, "shutdown", eventCallback, eventData.addr)
-
-proc execStartupEvents*(config: AppConfig, state: WidgetState) =
-  for event in config.startupEvents:
-    event(config.widget, state)
+proc execStartupEvents*(context: AppContext) =
+  for event in context.startupEvents:
+    event(context.state)
     
-proc execShutdownEvents*(config: AppConfig) =
-  for event in config.shutdownEvents:
-    event(config.widget)
+proc execShutdownEvents*(context: AppContext) =
+  for event in context.shutdownEvents:
+    event(context.state)
 
 proc setupApp*(config: AppConfig): WidgetState =
   if config.darkTheme:

--- a/owlkettle/mainloop.nim
+++ b/owlkettle/mainloop.nim
@@ -65,15 +65,36 @@ proc loadStylesheet*(path: string, priority: int = DEFAULT_PRIORITY): Stylesheet
     raise newException(IOError, $error[].message)
   result = Stylesheet(provider: provider, priority: priority)
 
-type AppConfig* = object of RootObj
-  widget*: Widget
-  icons*: seq[string]
-  darkTheme*: bool
-  stylesheets*: seq[Stylesheet]
-
-type StartUpEvent* = proc(data: AppConfig)
+type 
+  AppConfig* = object of RootObj
+    widget*: Widget
+    icons*: seq[string]
+    darkTheme*: bool
+    stylesheets*: seq[Stylesheet]
+    startupEvents*: seq[ApplicationEvent]
+    shutdownEvents*: seq[ApplicationEvent]
   
-type ShutDownEvent* = StartUpEvent
+  ApplicationEvent* = proc(widget: Widget, state: WidgetState)
+  
+# proc registerEvents*(app: GApplication, config: AppConfig, state: WidgetState) =
+#   proc eventCallback(app: GApplication, data: ptr AppData) {.cdecl.} =
+#     data[].event(data[].config, data[].event)
+  
+#   for event in config.startupEvents:
+#     let eventData = AppEventData(config: config, state: state, event: event)
+#     discard g_signal_connect(app, "startup", eventCallback, eventData.addr)
+
+#   for event in config.shutdownEvents:
+#     let eventData = AppEventData(config: config, state: state, event: event)
+#     discard g_signal_connect(app, "shutdown", eventCallback, eventData.addr)
+
+proc execStartupEvents*(config: AppConfig, state: WidgetState) =
+  for event in config.startupEvents:
+    event(config.widget, state)
+    
+proc execShutdownEvents*(config: AppConfig, state: WidgetState) =
+  for event in config.shutdownEvents:
+    event(config.widget, state)
 
 proc setupApp*(config: AppConfig): WidgetState =
   if config.darkTheme:

--- a/owlkettle/mainloop.nim
+++ b/owlkettle/mainloop.nim
@@ -71,6 +71,10 @@ type AppConfig* = object of RootObj
   darkTheme*: bool
   stylesheets*: seq[Stylesheet]
 
+type StartUpEvent* = proc(data: AppConfig)
+  
+type ShutDownEvent* = StartUpEvent
+
 proc setupApp*(config: AppConfig): WidgetState =
   if config.darkTheme:
     let settings = gtk_settings_get_default()


### PR DESCRIPTION
This is a first draft of adding startup/shutdown events to the various brew procs. I tested them manually, so they should all work.
The approach is as discussed, introduction of a new datatype.
In the GApplication-variants I use the "shutdown" signal, in the others I just execute the events after the runMainloop proc.
In the GApplication-variants I add startup to the "activate" signal, in the others I just execute the events before the runMainloop proc. 

I have not proofread this properly yet, this is just a jump-off point for a basis.
I can definitely confirm that it works at least, as I use this branch with `--path:` to cross-develop it with appster for better integration.

closes #148