### PR TITLE
chore(adw.nim): fix typo in build flag comment

### DIFF
--- a/owlkettle/bindings/adw.nim
+++ b/owlkettle/bindings/adw.nim
@@ -25,7 +25,7 @@
 import ./gtk
 
 const AdwMajor {.intdefine: "adwmajor".}: int = 1 ## Specifies the minimum Adwaita major version required to run an application. Overwriteable via `-d:adwmajor=X`. Defaults to 1.
-const AdwMinor {.intdefine: "adwminor".}: int = 0 ## Specifies the minimum Adwaita minor version required to run an application. Overwriteable via `-d:adwinor=X`. Defaults to 0.
+const AdwMinor {.intdefine: "adwminor".}: int = 0 ## Specifies the minimum Adwaita minor version required to run an application. Overwriteable via `-d:adwminor=X`. Defaults to 0.
 const AdwVersion* = (AdwMajor, AdwMinor)
 
 {.passl: "-ladwaita-1".}


### PR DESCRIPTION
While looking on how to use the newer adwaita widgets I noticed I couldn't use them because my `AdwVersion`  was `1.0` and I wondered why, although I have `1.4` installed.
I searched for `AdwVersion` in the repo and found the comment about how to set the adwaita version via a build flag. That worked in the end (yay, fancy AboutWindow works now :slightly_smiling_face: ), but it had a small typo. This PR fixes the typo.

Perhaps this is important enough to be included in the readme as well, but I wanted to keep it simple for this first PR.