### PR TITLE
#115 WIP Request for Code-Style Review when it comes to DSL

### DIFF
--- a/owlkettle/widgetdef.nim
+++ b/owlkettle/widgetdef.nim
@@ -442,18 +442,36 @@ proc substituteWidgets(node: NimNode): NimNode =
         result.add(substituteWidgets(child))
 
 proc genState(def: WidgetDef): NimNode =
-  result = newTree(nnkRecList)
+  ## Generates the WidgetState for the widget defined in def.
+  ## The type is generated according to the pattern:
+  ## ```
+  ## type <WidgetName>State = ref object of X
+  ##   <WidgetName>Ref: StateRef[<WidgetName>State]
+  ##   --- Repeat per field in def.fields - start ---
+  ##     <fieldName>: <fieldType>
+  ##   --- Repeat per field in def.fields - end ---
+  ##   --- Repeat per event in def.events - start ---
+  ##     <eventName>: Event[proc(<eventParameters>)]
+  ##   --- Repeat per event in def.events - end ---
+  ## ```
+  var fieldNodes = newTree(nnkRecList)
+  
+  # Add data fields  
   for field in def.fields:
     var fieldType = field.typ
     if def.kind == WidgetRenderable:
       fieldType = substituteWidgets(fieldType)
-    result.add(newTree(nnkIdentDefs, [
+    fieldNodes.add(newTree(nnkIdentDefs, [
       ident(field.name).newExport(not field.isPrivate),
       fieldType,
       newEmptyNode()
     ]))
+    
+  # Add event fields
   for event in def.events:
-    result.add(event.genIdentDefs())
+    fieldNodes.add(event.genIdentDefs())
+  
+  # Generate Type
   result = newTree(nnkTypeDef, [
     ident(def.stateName),
     newEmptyNode(),
@@ -461,7 +479,7 @@ proc genState(def: WidgetDef): NimNode =
       newTree(nnkObjectTy, [
         newEmptyNode(),
         newTree(nnkOfInherit, def.stateBase),
-        result
+        fieldNodes
       ])
     ])
   ])


### PR DESCRIPTION
This PR is a draft to demonstrate how I plan on acting while in the DSL part of the code.

Given that macros and DSLs in general have a tendency to be pretty mean in terms of complexity, I developed a few habits over the years to structure those well enough so I can more easily get back into it after a while.

I plan on introducing some of those in the owlkettle DSL because I believe them to be beneficial to the overall project and for readability.

I wanted to open up this PR to already show you how I tend to act on every proc I touch when it comes to these to give you the chance to veto any of these habits up front.

In general:
-Add doc comments to any proc involved in code generation. Even private procs.
Procs that generate NimNodes and thus Code directly I also annotate with a pattern that demonstrates *what* they generate (see doc comment in the code)
- A variable should always only hold one type of NimNodeKind.
I just found it a ton easier to reason about what a given NimNode is if I can know for sure what NimNodeKind it is.
That's visible here in how I replaced the bits of result with var fieldName until the final code generation step
- Separate sections in a proc into either smaller procs with fitting names, or at the very least split with doc comments. Code-generating related procs tend to become hard to see what they're about really fast, which is why I have this rule so you have *something* that allows you to see at a glance what this codeblock is about.