### PR TITLE
Add Adw.Spinner

### DIFF
--- a/examples/widgets/adw/spinner.nim
+++ b/examples/widgets/adw/spinner.nim
@@ -1,0 +1,45 @@
+# MIT License
+# 
+# Copyright (c) 2025 Can Joshua Lehmann
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import owlkettle, owlkettle/[playground, adw]
+
+viewable App:
+  showSpinner:
+    bool = false
+  sizeRequest:
+    tuple[x, y: int] = (-1, -1)
+
+method view(app: AppState): Widget =
+  result = gui:
+    Window:
+      defaultSize = (400, 200)
+      title = "Spinner Example"
+
+      Box(orient = OrientY):
+        if app.showSpinner:
+          AdwSpinner()
+
+        Button(text = "Spin eternally"):
+          proc clicked() =
+            app.showSpinner = not app.showSpinner
+
+adw.brew(gui(App()))

--- a/owlkettle/adw.nim
+++ b/owlkettle/adw.nim
@@ -47,61 +47,67 @@ when defined(owlkettleDocs) and isMainModule:
 
 renderable AdwWindow of BaseWindow:
   ## A Window that does not have a title bar.
-  content: Widget
-  
+  content:
+    Widget
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_window_new()
-  
+
   hooks content:
     (build, update):
       state.updateChild(state.content, widget.valContent, adw_window_set_content)
-  
+
   adder add:
     ## Adds a child to the window surface. Each window surface may only have one child.
     if widget.hasContent:
-      raise newException(ValueError, "Unable to add multiple children to a AdwWindow. Use a Box widget to display multiple widgets in a AdwWindow.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a AdwWindow. Use a Box widget to display multiple widgets in a AdwWindow.",
+      )
     widget.hasContent = true
     widget.valContent = child
-  
+
   example:
     AdwWindow:
       Box:
         orient = OrientX
-        
+
         Box {.expand: false.}:
           sizeRequest = (250, -1)
           orient = OrientY
-          
+
           HeaderBar {.expand: false.}:
             showTitleButtons = false
-          
+
           Label(text = "Sidebar")
-        
+
         Separator() {.expand: false.}
-        
+
         Box:
           orient = OrientY
-          
+
           HeaderBar() {.expand: false.}
           Label(text = "Main Content")
 
 renderable WindowTitle of BaseWidget:
-  title: string
-  subtitle: string
-  
+  title:
+    string
+  subtitle:
+    string
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_window_title_new(cstring(""), cstring(""))
-  
+
   hooks title:
     property:
       adw_window_title_set_title(state.internalWidget, state.title.cstring)
-  
+
   hooks subtitle:
     property:
       adw_window_title_set_subtitle(state.internalWidget, state.subtitle.cstring)
-  
+
   example:
     Window:
       HeaderBar {.addTitlebar.}:
@@ -110,35 +116,37 @@ renderable WindowTitle of BaseWidget:
           subtitle = "Subtitle"
 
 renderable Avatar of BaseWidget:
-  text: string
-  size: int
-  showInitials: bool
-  iconName: string = "avatar-default-symbolic"
-  
+  text:
+    string
+  size:
+    int
+  showInitials:
+    bool
+  iconName:
+    string = "avatar-default-symbolic"
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_avatar_new(
-        widget.valSize.cint,
-        widget.valText.cstring,
-        widget.valShow_initials.ord.cbool
+        widget.valSize.cint, widget.valText.cstring, widget.valShow_initials.ord.cbool
       )
-  
+
   hooks text:
     property:
       adw_avatar_set_text(state.internalWidget, state.text.cstring)
-  
+
   hooks size:
     property:
       adw_avatar_set_size(state.internalWidget, state.size.cint)
-  
+
   hooks showInitials:
     property:
       adw_avatar_set_show_initials(state.internalWidget, state.showInitials.ord.cbool)
-  
+
   hooks iconName:
     property:
       adw_avatar_set_icon_name(state.internalWidget, state.iconName.cstring)
-  
+
   example:
     Avatar:
       text = "Erika Mustermann"
@@ -146,223 +154,261 @@ renderable Avatar of BaseWidget:
       showInitials = true
 
 renderable ButtonContent of BaseWidget:
-  label: string
-  iconName: string
-  useUnderline: bool ## Defines whether you can use `_` on part of the label to make the button accessible via hotkey. If you prefix a character of the label text with `_` it will hide the `_` and activate the button if you press ALT + the key of the character. E.g. `_Button Text` will trigger the button when pressing `ALT + B`.
-  canShrink {.since: AdwVersion >= (1, 4).}: bool ## Defines whether the ButtonContent can be smaller than the size of its contents.
-  
+  label:
+    string
+  iconName:
+    string
+  useUnderline:
+    bool
+    ## Defines whether you can use `_` on part of the label to make the button accessible via hotkey. If you prefix a character of the label text with `_` it will hide the `_` and activate the button if you press ALT + the key of the character. E.g. `_Button Text` will trigger the button when pressing `ALT + B`.
+  canShrink {.since: AdwVersion >= (1, 4).}:
+    bool
+    ## Defines whether the ButtonContent can be smaller than the size of its contents.
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_button_content_new()
-  
+
   hooks label:
     property:
       adw_button_content_set_label(state.internalWidget, state.label.cstring)
-    
+
   hooks iconName:
     property:
       adw_button_content_set_icon_name(state.internalWidget, state.iconName.cstring)
-    
+
   hooks useUnderline:
     property:
-      adw_button_content_set_use_underline(state.internalWidget, state.useUnderline.cbool)
-  
+      adw_button_content_set_use_underline(
+        state.internalWidget, state.useUnderline.cbool
+      )
+
   hooks canShrink:
     property:
       adw_button_content_set_can_shrink(state.internalWidget, state.canShrink.cbool)
 
 renderable Clamp of BaseWidget:
-  maximumSize: int ## Maximum width of the content
-  child: Widget
-  
+  maximumSize:
+    int ## Maximum width of the content
+  child:
+    Widget
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_clamp_new()
-  
+
   hooks maximumSize:
     property:
       adw_clamp_set_maximum_size(state.internalWidget, cint(state.maximumSize))
-  
+
   hooks child:
     (build, update):
       state.updateChild(state.child, widget.valChild, adw_clamp_set_child)
-  
+
   adder add:
     if widget.hasChild:
-      raise newException(ValueError, "Unable to add multiple children to a Clamp. Use a Box widget to display multiple widgets in a Clamp.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a Clamp. Use a Box widget to display multiple widgets in a Clamp.",
+      )
     widget.hasChild = true
     widget.valChild = child
-  
+
   example:
     Clamp:
       maximumSize = 600
       margin = 12
-      
+
       PreferencesGroup:
         title = "Settings"
 
 renderable PreferencesGroup of BaseWidget:
-  title: string
-  description: string
-  children: seq[Widget]
-  suffix: Widget
-  
+  title:
+    string
+  description:
+    string
+  children:
+    seq[Widget]
+  suffix:
+    Widget
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_preferences_group_new()
-  
+
   hooks title:
     property:
       adw_preferences_group_set_title(state.internalWidget, state.title.cstring)
-  
+
   hooks description:
     property:
-      adw_preferences_group_set_description(state.internalWidget, state.description.cstring)
-  
+      adw_preferences_group_set_description(
+        state.internalWidget, state.description.cstring
+      )
+
   hooks suffix:
     (build, update):
-      state.updateChild(state.suffix, widget.valSuffix, adw_preferences_group_set_header_suffix)
-  
+      state.updateChild(
+        state.suffix, widget.valSuffix, adw_preferences_group_set_header_suffix
+      )
+
   hooks children:
     (build, update):
       state.updateChildren(
-        state.children,
-        widget.valChildren,
-        adw_preferences_group_add,
-        adw_preferences_group_remove
+        state.children, widget.valChildren, adw_preferences_group_add,
+        adw_preferences_group_remove,
       )
-  
+
   adder add:
     widget.hasChildren = true
     widget.valChildren.add(child)
-  
+
   adder addSuffix:
     if widget.hasSuffix:
-      raise newException(ValueError, "Unable to add multiple suffixes to a PreferencesGroup. Use a Box widget to display multiple widgets in a PreferencesGroup.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple suffixes to a PreferencesGroup. Use a Box widget to display multiple widgets in a PreferencesGroup.",
+      )
     widget.hasSuffix = true
     widget.valSuffix = child
-  
+
   example:
     PreferencesGroup:
       title = "Settings"
       description = "Application Settings"
-      
+
       ActionRow:
         title = "My Setting"
         subtitle = "Subtitle"
         Switch() {.addSuffix.}
 
 renderable PreferencesPage of BaseWidget:
-  preferences: seq[Widget]
-  iconName: string
-  name: string
-  title: string
-  useUnderline: bool
-  description {.since: AdwVersion >= (1, 4).}: string
-  
+  preferences:
+    seq[Widget]
+  iconName:
+    string
+  name:
+    string
+  title:
+    string
+  useUnderline:
+    bool
+  description {.since: AdwVersion >= (1, 4).}:
+    string
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_preferences_page_new()
-  
+
   hooks preferences:
     (build, update):
       state.updateChildren(
-        state.preferences,
-        widget.valPreferences,
-        adw_preferences_page_add,
-        adw_preferences_page_remove
+        state.preferences, widget.valPreferences, adw_preferences_page_add,
+        adw_preferences_page_remove,
       )
-  
+
   hooks iconName:
     property:
       adw_preferences_page_set_icon_name(state.internalWidget, state.iconName.cstring)
-  
+
   hooks name:
     property:
       adw_preferences_page_set_name(state.internalWidget, state.name.cstring)
-      
+
   hooks title:
     property:
       adw_preferences_page_set_title(state.internalWidget, state.title.cstring)
-      
+
   hooks useUnderline:
     property:
-      adw_preferences_page_set_use_underline(state.internalWidget, state.useUnderline.cbool)
-      
+      adw_preferences_page_set_use_underline(
+        state.internalWidget, state.useUnderline.cbool
+      )
+
   hooks description:
     property:
-      adw_preferences_page_set_description(state.internalWidget, state.description.cstring)
-  
+      adw_preferences_page_set_description(
+        state.internalWidget, state.description.cstring
+      )
+
   adder add:
     widget.valPreferences.add(child)
-  
 
 renderable PreferencesRow of ListBoxRow:
-  title: string
-  
+  title:
+    string
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_preferences_row_new()
-  
+
   hooks title:
     property:
       adw_preferences_row_set_title(state.internalWidget, state.title.cstring)
 
 renderable ActionRow of PreferencesRow:
-  subtitle: string
-  suffixes: seq[AlignedChild[Widget]]
-  
+  subtitle:
+    string
+  suffixes:
+    seq[AlignedChild[Widget]]
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_action_row_new()
-  
+
   hooks subtitle:
     property:
       adw_action_row_set_subtitle(state.internalWidget, state.subtitle.cstring)
-  
+
   hooks suffixes:
     (build, update):
-      state.updateAlignedChildren(state.suffixes, widget.valSuffixes,
-        adw_action_row_add_suffix,
-        adw_action_row_remove
+      state.updateAlignedChildren(
+        state.suffixes, widget.valSuffixes, adw_action_row_add_suffix,
+        adw_action_row_remove,
       )
 
   adder addSuffix {.hAlign: AlignFill, vAlign: AlignCenter.}:
     widget.hasSuffixes = true
-    widget.valSuffixes.add(AlignedChild[Widget](
-      widget: child,
-      hAlign: hAlign,
-      vAlign: vAlign
-    ))
-  
+    widget.valSuffixes.add(
+      AlignedChild[Widget](widget: child, hAlign: hAlign, vAlign: vAlign)
+    )
+
   example:
     ActionRow:
       title = "Color"
       subtitle = "Color of the object"
-      
+
       ColorButton {.addSuffix.}:
         discard
 
 renderable ExpanderRow of PreferencesRow:
-  subtitle: string
-  actions: seq[AlignedChild[Widget]]
-  rows: seq[AlignedChild[Widget]]
-  expanded: bool = false
-  enableExpansion: bool = true
-  showEnableSwitch: bool = false
-  titleLines {.since: AdwVersion >= (1, 3).}: int ## Determines how many lines of text from the title are shown before it ellipsizes the text. Defaults to 0 which means it never elipsizes and instead adds new lines to show the full text. 
-  subtitleLines {.since: AdwVersion >= (1, 3).}: int  ## Determines how many lines of text from the subtitle are shown before it ellipsizes the text. Defaults to 0 which means it never elipsizes and instead adds new lines to show the full text.
-  
+  subtitle:
+    string
+  actions:
+    seq[AlignedChild[Widget]]
+  rows:
+    seq[AlignedChild[Widget]]
+  expanded:
+    bool = false
+  enableExpansion:
+    bool = true
+  showEnableSwitch:
+    bool = false
+  titleLines {.since: AdwVersion >= (1, 3).}:
+    int
+    ## Determines how many lines of text from the title are shown before it ellipsizes the text. Defaults to 0 which means it never elipsizes and instead adds new lines to show the full text. 
+  subtitleLines {.since: AdwVersion >= (1, 3).}:
+    int
+    ## Determines how many lines of text from the subtitle are shown before it ellipsizes the text. Defaults to 0 which means it never elipsizes and instead adds new lines to show the full text.
+
   proc expand(newExpandState: bool) ## Triggered when row gets expanded
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_expander_row_new()
     connectEvents:
       proc expandCallback(
-        widget: GtkWidget,
-        pspec: pointer,
-        data: ptr EventObj[proc (isExpanded: bool)]
+          widget: GtkWidget, pspec: pointer, data: ptr EventObj[proc(isExpanded: bool)]
       ) {.cdecl.} =
         logExceptions:
           let
@@ -371,7 +417,7 @@ renderable ExpanderRow of PreferencesRow:
           state.expanded = isExpanded
           data[].callback(isExpanded)
           data[].redraw()
-        
+
       state.connect(state.expand, "notify::expanded", expandCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.expand)
@@ -379,7 +425,7 @@ renderable ExpanderRow of PreferencesRow:
   hooks subtitle:
     property:
       adw_expander_row_set_subtitle(state.internalWidget, state.subtitle.cstring)
-  
+
   hooks actions:
     (build, update):
       const rowAdder =
@@ -387,76 +433,78 @@ renderable ExpanderRow of PreferencesRow:
           adw_expander_row_add_suffix
         else:
           adw_expander_row_add_action
-      
-      state.updateAlignedChildren(state.actions, widget.valActions,
-        rowAdder,
-        adw_expander_row_remove
+
+      state.updateAlignedChildren(
+        state.actions, widget.valActions, rowAdder, adw_expander_row_remove
       )
-  
+
   hooks rows:
     (build, update):
-      state.updateAlignedChildren(state.rows, widget.valRows,
-        adw_expander_row_add_row,
-        adw_expander_row_remove
+      state.updateAlignedChildren(
+        state.rows, widget.valRows, adw_expander_row_add_row, adw_expander_row_remove
       )
-  
+
   hooks expanded:
     property:
       adw_expander_row_set_expanded(state.internalWidget, state.expanded.cbool)
-      
+
   hooks enableExpansion:
     property:
-      adw_expander_row_set_enable_expansion(state.internalWidget, state.enableExpansion.cbool)
-        
+      adw_expander_row_set_enable_expansion(
+        state.internalWidget, state.enableExpansion.cbool
+      )
+
   hooks showEnableSwitch:
     property:
-      adw_expander_row_set_show_enable_switch(state.internalWidget, state.showEnableSwitch.cbool)
-      
+      adw_expander_row_set_show_enable_switch(
+        state.internalWidget, state.showEnableSwitch.cbool
+      )
+
   hooks titleLines:
     property:
       adw_expander_row_set_title_lines(state.internalWidget, state.titleLines.cint)
 
   hooks subtitleLines:
     property:
-      adw_expander_row_set_subtitle_lines(state.internalWidget, state.subtitleLines.cint)
+      adw_expander_row_set_subtitle_lines(
+        state.internalWidget, state.subtitleLines.cint
+      )
 
   adder addAction {.hAlign: AlignFill, vAlign: AlignCenter.}:
     widget.hasActions = true
-    widget.valActions.add(AlignedChild[Widget](
-      widget: child,
-      hAlign: hAlign,
-      vAlign: vAlign
-    ))
-  
+    widget.valActions.add(
+      AlignedChild[Widget](widget: child, hAlign: hAlign, vAlign: vAlign)
+    )
+
   adder addRow {.hAlign: AlignFill, vAlign: AlignFill.}:
     widget.hasRows = true
-    widget.valRows.add(AlignedChild[Widget](
-      widget: child,
-      hAlign: hAlign,
-      vAlign: vAlign
-    ))
-  
+    widget.valRows.add(
+      AlignedChild[Widget](widget: child, hAlign: hAlign, vAlign: vAlign)
+    )
+
   example:
     ExpanderRow:
       title = "Expander Row"
-      
-      for it in 0..<3:
+
+      for it in 0 ..< 3:
         ActionRow {.addRow.}:
           title = "Nested Row " & $it
 
 renderable ComboRow of ActionRow:
-  items: seq[string]
-  selected: int
-  
+  items:
+    seq[string]
+  selected:
+    int
+
   proc select(item: int)
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_combo_row_new()
     connectEvents:
-      proc selectCallback(widget: GtkWidget,
-                          pspec: pointer,
-                          data: ptr EventObj[proc (item: int)]) {.cdecl.} =
+      proc selectCallback(
+          widget: GtkWidget, pspec: pointer, data: ptr EventObj[proc(item: int)]
+      ) {.cdecl.} =
         logExceptions:
           let
             selected = int(adw_combo_row_get_selected(widget))
@@ -465,58 +513,63 @@ renderable ComboRow of ActionRow:
             state.selected = selected
             data[].callback(selected)
             data[].redraw()
-      
+
       state.connect(state.select, "notify::selected", selectCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.select)
-  
+
   hooks items:
     property:
       let items = allocCStringArray(state.items)
-      defer: deallocCStringArray(items)
+      defer:
+        deallocCStringArray(items)
       adw_combo_row_set_model(state.internalWidget, gtk_string_list_new(items))
-  
+
   hooks selected:
     property:
       adw_combo_row_set_selected(state.internalWidget, cuint(state.selected))
-  
+
   example:
     ComboRow:
       title = "Combo Row"
       items = @["Option 1", "Option 2", "Option 3"]
-      
+
       selected = app.selected
       proc select(item: int) =
         app.selected = item
 
 renderable EntryRow {.since: AdwVersion >= (1, 2).} of PreferencesRow:
-  suffixes: seq[AlignedChild[Widget]]
-  text: string
-  
+  suffixes:
+    seq[AlignedChild[Widget]]
+  text:
+    string
+
   proc changed(text: string)
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_entry_row_new()
     connectEvents:
-      proc changedCallback(widget: GtkWidget, data: ptr EventObj[proc (text: string)]) {.cdecl.} =
+      proc changedCallback(
+          widget: GtkWidget, data: ptr EventObj[proc(text: string)]
+      ) {.cdecl.} =
         logExceptions:
           let text = $gtk_editable_get_text(widget)
           EntryRowState(data[].widget).text = text
           data[].callback(text)
           data[].redraw()
-      
+
       state.connect(state.changed, "changed", changedCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.changed)
-  
+
   hooks suffixes:
     (build, update):
-      state.updateAlignedChildren(state.suffixes, widget.valSuffixes,
-        adw_entry_row_add_suffix,
-        adw_entry_row_remove
+      state.updateAlignedChildren(
+        state.suffixes, widget.valSuffixes, adw_entry_row_add_suffix,
+        adw_entry_row_remove,
       )
-  
+
   hooks text:
     property:
       gtk_editable_set_text(state.internalWidget, state.text.cstring)
@@ -525,32 +578,30 @@ renderable EntryRow {.since: AdwVersion >= (1, 2).} of PreferencesRow:
 
   adder addSuffix {.hAlign: AlignFill, vAlign: AlignCenter.}:
     widget.hasSuffixes = true
-    widget.valSuffixes.add(AlignedChild[Widget](
-      widget: child,
-      hAlign: hAlign,
-      vAlign: vAlign
-    ))
-  
+    widget.valSuffixes.add(
+      AlignedChild[Widget](widget: child, hAlign: hAlign, vAlign: vAlign)
+    )
+
   example:
     EntryRow:
       title = "Name"
       text = app.name
-      
+
       proc changed(name: string) =
         app.name = name
 
 renderable PasswordEntryRow {.since: AdwVersion >= (1, 2).} of EntryRow:
   ## An `EntryRow` that hides the user input
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_password_entry_row_new()
-  
+
   example:
     PasswordEntryRow:
       title = "Password"
       text = app.password
-      
+
       proc changed(password: string) =
         app.password = password
 
@@ -559,28 +610,39 @@ type FlapChild[T] = object
   width: int
 
 renderable Flap:
-  content: Widget
-  separator: Widget
-  flap: FlapChild[Widget]
-  revealed: bool = false
-  foldPolicy: FlapFoldPolicy = FlapFoldAuto
-  foldThresholdPolicy: FoldThresholdPolicy = FoldThresholdNatural
-  transitionType: FlapTransitionType = FlapTransitionOver
-  modal: bool = true
-  locked: bool = false
-  swipeToClose: bool = true
-  swipeToOpen: bool = true
-  
+  content:
+    Widget
+  separator:
+    Widget
+  flap:
+    FlapChild[Widget]
+  revealed:
+    bool = false
+  foldPolicy:
+    FlapFoldPolicy = FlapFoldAuto
+  foldThresholdPolicy:
+    FoldThresholdPolicy = FoldThresholdNatural
+  transitionType:
+    FlapTransitionType = FlapTransitionOver
+  modal:
+    bool = true
+  locked:
+    bool = false
+  swipeToClose:
+    bool = true
+  swipeToOpen:
+    bool = true
+
   proc changed(revealed: bool)
   proc fold(folded: bool)
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_flap_new()
     connectEvents:
-      proc changedCallback(widget: GtkWidget,
-                           pspec: pointer,
-                           data: ptr EventObj[proc (state: bool)]) {.cdecl.} =
+      proc changedCallback(
+          widget: GtkWidget, pspec: pointer, data: ptr EventObj[proc(state: bool)]
+      ) {.cdecl.} =
         logExceptions:
           let
             revealed = adw_flap_get_reveal_flap(widget) != 0
@@ -589,53 +651,55 @@ renderable Flap:
             state.revealed = revealed
             data[].callback(revealed)
             data[].redraw()
-      
+
       state.connect(state.changed, "notify::reveal-flap", changedCallback)
-      
-      proc foldCallback(widget: GtkWidget,
-                        pspec: pointer,
-                        data: ptr EventObj[proc (state: bool)]) {.cdecl.} =
+
+      proc foldCallback(
+          widget: GtkWidget, pspec: pointer, data: ptr EventObj[proc(state: bool)]
+      ) {.cdecl.} =
         logExceptions:
           data[].callback(adw_flap_get_folded(widget) != 0)
           data[].redraw()
-      
+
       state.connect(state.fold, "notify::folded", foldCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.changed)
       state.internalWidget.disconnect(state.fold)
-  
+
   hooks foldPolicy:
     property:
       adw_flap_set_fold_policy(state.internal_widget, state.foldPolicy)
-  
+
   hooks foldThresholdPolicy:
     property:
-      adw_flap_set_fold_threshold_policy(state.internal_widget, state.foldThresholdPolicy)
-  
+      adw_flap_set_fold_threshold_policy(
+        state.internal_widget, state.foldThresholdPolicy
+      )
+
   hooks transitionType:
     property:
       adw_flap_set_transition_type(state.internal_widget, state.transitionType)
-  
+
   hooks revealed:
     property:
       adw_flap_set_reveal_flap(state.internal_widget, cbool(ord(state.revealed)))
-  
+
   hooks modal:
     property:
       adw_flap_set_modal(state.internal_widget, cbool(ord(state.modal)))
-  
+
   hooks locked:
     property:
       adw_flap_set_locked(state.internal_widget, cbool(ord(state.locked)))
-  
+
   hooks swipeToOpen:
     property:
       adw_flap_set_swipe_to_open(state.internal_widget, cbool(ord(state.swipeToOpen)))
-  
+
   hooks swipeToClose:
     property:
       adw_flap_set_swipe_to_close(state.internal_widget, cbool(ord(state.swipeToClose)))
-  
+
   hooks flap:
     (build, update):
       if widget.hasFlap:
@@ -651,52 +715,59 @@ renderable Flap:
           let styleContext = gtk_widget_get_style_context(childWidget)
           gtk_style_context_add_class(styleContext, "background")
           state.flap.widget = newChild
-        
+
         if state.flap.width != widget.valFlap.width:
           state.flap.width = widget.valFlap.width
           let childWidget = state.flap.widget.unwrapInternalWidget()
           gtk_widget_set_size_request(childWidget, cint(state.flap.width), -1)
-  
+
   hooks separator:
     (build, update):
       state.updateChild(state.separator, widget.valSeparator, adw_flap_set_separator)
-  
+
   hooks content:
     (build, update):
       state.updateChild(state.content, widget.valContent, adw_flap_set_content)
-  
-  setter swipe: bool
-  
+
+  setter swipe:
+    bool
+
   adder add:
     if widget.hasContent:
-      raise newException(ValueError, "Unable to add multiple children to a adw.Flap. Use a Box widget to display multiple widgets in a adw.Flap.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a adw.Flap. Use a Box widget to display multiple widgets in a adw.Flap.",
+      )
     widget.hasContent = true
     widget.valContent = child
-  
+
   adder addSeparator:
     if widget.hasSeparator:
       raise newException(ValueError, "Unable to add multiple separators to a adw.Flap.")
     widget.hasSeparator = true
     widget.valSeparator = child
-  
+
   adder addFlap {.width: -1.}:
     if widget.hasFlap:
-      raise newException(ValueError, "Unable to add multiple flaps to a adw.Flap. Use a Box widget to display multiple widgets in a adw.Flap.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple flaps to a adw.Flap. Use a Box widget to display multiple widgets in a adw.Flap.",
+      )
     widget.hasFlap = true
     widget.valFlap = FlapChild[Widget](widget: child, width: width)
-  
+
   example:
     Flap:
       revealed = app.showFlap
       transitionType = FlapTransitionOver
-      
+
       proc changed(revealed: bool) =
         app.showFlap = revealed
-      
+
       Label(text = "Flap") {.addFlap, width: 200.}
-      
+
       Separator() {.addSeparator.}
-      
+
       Box:
         Label:
           text = "Content ".repeat(10)
@@ -711,28 +782,40 @@ proc `valSwipe=`*(flap: Flap, swipe: bool) =
   flap.valSwipeToClose = swipe
 
 renderable OverlaySplitView {.since: AdwVersion >= (1, 4).} of BaseWidget:
-  content: Widget
-  sidebar: Widget
-  collapsed: bool = false
-  enableHideGesture: bool = true
-  enableShowGesture: bool = true
-  maxSidebarWidth: float = 280.0
-  minSidebarWidth: float = 180.0
-  pinSidebar: bool = false
-  showSidebar: bool = true
-  sidebarPosition: PackType = PackStart
-  widthFraction: float = 0.25
-  widthUnit: LengthUnit = LengthScaleIndependent
-  
+  content:
+    Widget
+  sidebar:
+    Widget
+  collapsed:
+    bool = false
+  enableHideGesture:
+    bool = true
+  enableShowGesture:
+    bool = true
+  maxSidebarWidth:
+    float = 280.0
+  minSidebarWidth:
+    float = 180.0
+  pinSidebar:
+    bool = false
+  showSidebar:
+    bool = true
+  sidebarPosition:
+    PackType = PackStart
+  widthFraction:
+    float = 0.25
+  widthUnit:
+    LengthUnit = LengthScaleIndependent
+
   proc toggle(shown: bool)
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_overlay_split_view_new()
     connectEvents:
-      proc toggleCallback(widget: GtkWidget,
-                          spec: pointer,
-                          data: ptr EventObj[proc (show: bool)]) {.cdecl.} =
+      proc toggleCallback(
+          widget: GtkWidget, spec: pointer, data: ptr EventObj[proc(show: bool)]
+      ) {.cdecl.} =
         logExceptions:
           let
             showSidebar = adw_overlay_split_view_get_show_sidebar(widget) != 0
@@ -741,169 +824,210 @@ renderable OverlaySplitView {.since: AdwVersion >= (1, 4).} of BaseWidget:
             state.showSidebar = showSidebar
             data[].callback(showSidebar)
             data[].redraw()
-      
+
       state.connect(state.toggle, "notify::show-sidebar", toggleCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.toggle)
-  
+
   hooks content:
     (build, update):
       state.updateChild(
-        state.content,
-        widget.valContent,
-        adw_overlay_split_view_set_content
+        state.content, widget.valContent, adw_overlay_split_view_set_content
       )
-  
+
   hooks sidebar:
     (build, update):
       state.updateChild(
-        state.sidebar,
-        widget.valSidebar,
-        adw_overlay_split_view_set_sidebar
+        state.sidebar, widget.valSidebar, adw_overlay_split_view_set_sidebar
       )
-  
+
   hooks collapsed:
     property:
       adw_overlay_split_view_set_collapsed(state.internalWidget, state.collapsed.cbool)
 
   hooks enableHideGesture:
     property:
-      adw_overlay_split_view_set_enable_hide_gesture(state.internalWidget, state.enableHideGesture.cbool)
+      adw_overlay_split_view_set_enable_hide_gesture(
+        state.internalWidget, state.enableHideGesture.cbool
+      )
 
   hooks enableShowGesture:
     property:
-      adw_overlay_split_view_set_enable_show_gesture(state.internalWidget, state.enableShowGesture.cbool)
+      adw_overlay_split_view_set_enable_show_gesture(
+        state.internalWidget, state.enableShowGesture.cbool
+      )
 
   hooks maxSidebarWidth:
     property:
-      adw_overlay_split_view_set_max_sidebar_width(state.internalWidget, state.maxSidebarWidth.cdouble)
+      adw_overlay_split_view_set_max_sidebar_width(
+        state.internalWidget, state.maxSidebarWidth.cdouble
+      )
 
   hooks minSidebarWidth:
     property:
-      adw_overlay_split_view_set_min_sidebar_width(state.internalWidget, state.minSidebarWidth.cdouble)
+      adw_overlay_split_view_set_min_sidebar_width(
+        state.internalWidget, state.minSidebarWidth.cdouble
+      )
 
   hooks pinSidebar:
     property:
-      adw_overlay_split_view_set_pin_sidebar(state.internalWidget, state.pinSidebar.cbool)
+      adw_overlay_split_view_set_pin_sidebar(
+        state.internalWidget, state.pinSidebar.cbool
+      )
 
   hooks showSidebar:
     property:
-      adw_overlay_split_view_set_show_sidebar(state.internalWidget, state.showSidebar.cbool)
+      adw_overlay_split_view_set_show_sidebar(
+        state.internalWidget, state.showSidebar.cbool
+      )
 
   hooks sidebarPosition:
     property:
-      adw_overlay_split_view_set_sidebar_position(state.internalWidget, state.sidebarPosition.toGtk())
+      adw_overlay_split_view_set_sidebar_position(
+        state.internalWidget, state.sidebarPosition.toGtk()
+      )
 
   hooks widthFraction:
     property:
-      adw_overlay_split_view_set_sidebar_width_fraction(state.internalWidget, state.widthFraction.cdouble)
+      adw_overlay_split_view_set_sidebar_width_fraction(
+        state.internalWidget, state.widthFraction.cdouble
+      )
 
   hooks widthUnit:
     property:
-      adw_overlay_split_view_set_sidebar_width_unit(state.internalWidget, state.widthUnit)
+      adw_overlay_split_view_set_sidebar_width_unit(
+        state.internalWidget, state.widthUnit
+      )
 
   adder add:
     if widget.hasContent:
-      raise newException(ValueError, "Unable to add multiple children to a OverlaySplitView. Use a Box widget to display multiple widgets!")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a OverlaySplitView. Use a Box widget to display multiple widgets!",
+      )
     widget.hasContent = true
     widget.valContent = child
-  
+
   adder addSidebar:
     if widget.hasSidebar:
-      raise newException(ValueError, "Unable to add multiple sidebars to a OverlaySplitView. Use a Box widget to display multiple widgets!")
+      raise newException(
+        ValueError,
+        "Unable to add multiple sidebars to a OverlaySplitView. Use a Box widget to display multiple widgets!",
+      )
     widget.hasSidebar = true
     widget.valSidebar = child
 
 renderable AdwHeaderBar of BaseWidget:
   ## Adwaita Headerbar that combines GTK Headerbar and WindowControls.
-  packLeft: seq[Widget]
-  packRight: seq[Widget]
-  centeringPolicy: CenteringPolicy = CenteringPolicyLoose
-  decorationLayout: Option[string] = none(string)
-  showRightButtons: bool = true ## Determines whether the buttons in `rightButtons` are shown. Does not affect Widgets in `packRight`.
-  showLeftButtons: bool = true ## Determines whether the buttons in `leftButtons` are shown. Does not affect Widgets in `packLeft`.
-  titleWidget: Widget ## A widget for the title. Replaces the title string, if there is one.
-  showBackButton {.since: AdwVersion >= (1, 4).}: bool = true
-  showTitle {.since: AdwVersion >= (1, 4).}: bool = true ## Determines whether to show or hide the title
-  
-  setter windowControls: DecorationLayout
-  setter windowControls: Option[DecorationLayout]
-  
+  packLeft:
+    seq[Widget]
+  packRight:
+    seq[Widget]
+  centeringPolicy:
+    CenteringPolicy = CenteringPolicyLoose
+  decorationLayout:
+    Option[string] = none(string)
+  showRightButtons:
+    bool = true
+    ## Determines whether the buttons in `rightButtons` are shown. Does not affect Widgets in `packRight`.
+  showLeftButtons:
+    bool = true
+    ## Determines whether the buttons in `leftButtons` are shown. Does not affect Widgets in `packLeft`.
+  titleWidget:
+    Widget ## A widget for the title. Replaces the title string, if there is one.
+  showBackButton {.since: AdwVersion >= (1, 4).}:
+    bool = true
+  showTitle {.since: AdwVersion >= (1, 4).}:
+    bool = true ## Determines whether to show or hide the title
+
+  setter windowControls:
+    DecorationLayout
+  setter windowControls:
+    Option[DecorationLayout]
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_header_bar_new()
-  
+
   hooks packRight:
     (build, update):
       state.updateChildren(
-        state.packRight,
-        widget.valPackRight,
-        adw_header_bar_pack_end,
-        adw_header_bar_remove
+        state.packRight, widget.valPackRight, adw_header_bar_pack_end,
+        adw_header_bar_remove,
       )
-      
+
   hooks packLeft:
     (build, update):
       state.updateChildren(
-        state.packLeft,
-        widget.valPackLeft,
-        adw_header_bar_pack_start,
-        adw_header_bar_remove
+        state.packLeft, widget.valPackLeft, adw_header_bar_pack_start,
+        adw_header_bar_remove,
       )
-      
+
   hooks centeringPolicy:
     property:
       adw_header_bar_set_centering_policy(state.internalWidget, state.centeringPolicy)
-  
+
   hooks decorationLayout:
     property:
       if state.decorationLayout.isSome():
-        adw_header_bar_set_decoration_layout(state.internalWidget, state.decorationLayout.get().cstring)
+        adw_header_bar_set_decoration_layout(
+          state.internalWidget, state.decorationLayout.get().cstring
+        )
       else:
         adw_header_bar_set_decoration_layout(state.internalWidget, nil)
-  
+
   hooks showRightButtons:
     property:
-      adw_header_bar_set_show_end_title_buttons(state.internalWidget, state.showRightButtons.cbool)
-  
+      adw_header_bar_set_show_end_title_buttons(
+        state.internalWidget, state.showRightButtons.cbool
+      )
+
   hooks showLeftButtons:
     property:
-      adw_header_bar_set_show_start_title_buttons(state.internalWidget, state.showLeftButtons.cbool)
-  
+      adw_header_bar_set_show_start_title_buttons(
+        state.internalWidget, state.showLeftButtons.cbool
+      )
+
   hooks titleWidget:
     (build, update):
       state.updateChild(
-        state.titleWidget,
-        widget.valTitleWidget,
-        adw_header_bar_set_title_widget
+        state.titleWidget, widget.valTitleWidget, adw_header_bar_set_title_widget
       )
-  
+
   hooks showBackButton:
     property:
-      adw_header_bar_set_show_back_button(state.internalWidget, state.showBackButton.cbool)
-  
+      adw_header_bar_set_show_back_button(
+        state.internalWidget, state.showBackButton.cbool
+      )
+
   hooks showTitle:
     property:
       adw_header_bar_set_show_title(state.internalWidget, state.showTitle.cbool)
-  
+
   adder addLeft:
     ## Adds a widget to the left side of the HeaderBar.
     widget.hasPackLeft = true
     widget.valPackLeft.add(child)
-  
+
   adder addRight:
     ## Adds a widget to the right side of the HeaderBar.
     widget.hasPackRight = true
     widget.valPackRight.add(child)
-  
+
   adder addTitle:
     when AdwVersion >= (1, 4):
       if widget.hasTitleWidget:
-        raise newException(ValueError, "Unable to add multiple children as title to HeaderBar. Use a Box widget to display multiple widgets.")
+        raise newException(
+          ValueError,
+          "Unable to add multiple children as title to HeaderBar. Use a Box widget to display multiple widgets.",
+        )
       widget.hasTitleWidget = true
       widget.valTitleWidget = child
     else:
-      raise newException(ValueError, "Compile for Adwaita version 1.4 or higher with -d:adwMinor=4 to enable setting a Title Widget for Headerbar.")
+      raise newException(
+        ValueError,
+        "Compile for Adwaita version 1.4 or higher with -d:adwMinor=4 to enable setting a Title Widget for Headerbar.",
+      )
 
 proc `hasWindowControls=`*(widget: AdwHeaderbar, has: bool) =
   widget.hasDecorationLayout = true
@@ -912,15 +1036,18 @@ proc `valWindowControls=`*(widget: AdwHeaderbar, buttons: DecorationLayout) =
   widget.valDecorationLayout = some(buttons.toLayoutString())
 
 proc `valWindowControls=`*(widget: AdwHeaderbar, buttons: Option[DecorationLayout]) =
-  let decorationLayout: Option[string] = buttons.map(controls => controls.toLayoutString())
+  let decorationLayout: Option[string] =
+    buttons.map(controls => controls.toLayoutString())
   widget.valDecorationLayout = decorationLayout
-  
+
 renderable SplitButton of BaseWidget:
-  child: Widget
-  popover: Widget
-    
+  child:
+    Widget
+  popover:
+    Widget
+
   proc clicked()
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_split_button_new()
@@ -928,24 +1055,29 @@ renderable SplitButton of BaseWidget:
       state.connect(state.clicked, "clicked", eventCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.clicked)
-  
+
   hooks child:
     (build, update):
       state.updateChild(state.child, widget.valChild, adw_split_button_set_child)
-  
+
   hooks popover:
     (build, update):
       state.updateChild(state.popover, widget.valPopover, adw_split_button_set_popover)
-  
-  setter text: string
-  setter icon: string ## Sets the icon of the SplitButton. See [recommended_tools.md](recommended_tools.md#icons) for a list of icons.
-  
+
+  setter text:
+    string
+  setter icon:
+    string ## Sets the icon of the SplitButton. See [recommended_tools.md](recommended_tools.md#icons) for a list of icons.
+
   adder addChild:
     if widget.hasChild:
-      raise newException(ValueError, "Unable to add multiple children to a SplitButton. Use a Box widget to display multiple widgets in a SplitButton.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a SplitButton. Use a Box widget to display multiple widgets in a SplitButton.",
+      )
     widget.hasChild = true
     widget.valChild = child
-  
+
   adder add:
     if not widget.hasChild:
       widget.hasChild = true
@@ -954,134 +1086,161 @@ renderable SplitButton of BaseWidget:
       widget.hasPopover = true
       widget.valPopover = child
     else:
-      raise newException(ValueError, "Unable to add more than two children to SplitButton")
+      raise
+        newException(ValueError, "Unable to add more than two children to SplitButton")
 
-proc `hasText=`*(splitButton: SplitButton, value: bool) = splitButton.hasChild = value
+proc `hasText=`*(splitButton: SplitButton, value: bool) =
+  splitButton.hasChild = value
+
 proc `valText=`*(splitButton: SplitButton, value: string) =
   splitButton.valChild = Label(hasText: true, valText: value)
 
-proc `hasIcon=`*(splitButton: SplitButton, value: bool) = splitButton.hasChild = value
+proc `hasIcon=`*(splitButton: SplitButton, value: bool) =
+  splitButton.hasChild = value
+
 proc `valIcon=`*(splitButton: SplitButton, name: string) =
   splitButton.valChild = Icon(hasName: true, valName: name)
 
 renderable StatusPage of BaseWidget:
-  iconName: string ## The icon to render in the center of the StatusPage. Setting this overrides paintable. See the [tooling](https://can-lehmann.github.io/owlkettle/docs/recommended_tools.html) section for how to figure out what icon names are available.
-  paintable: Widget ## The widget that implements GdkPaintable to render (e.g. IconPaintable, WidgetPaintable) in the center of the StatusPage. Setting this overrides iconName.
-  title: string
-  description: string
-  child: Widget
-  
+  iconName:
+    string
+    ## The icon to render in the center of the StatusPage. Setting this overrides paintable. See the [tooling](https://can-lehmann.github.io/owlkettle/docs/recommended_tools.html) section for how to figure out what icon names are available.
+  paintable:
+    Widget
+    ## The widget that implements GdkPaintable to render (e.g. IconPaintable, WidgetPaintable) in the center of the StatusPage. Setting this overrides iconName.
+  title:
+    string
+  description:
+    string
+  child:
+    Widget
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_status_page_new()
-  
+
   hooks iconName:
     property:
       adw_status_page_set_icon_name(state.internalWidget, state.iconName.cstring)
-  
+
   hooks paintable:
     (build, update):
-      state.updateChild(state.paintable, widget.valPaintable, adw_status_page_set_paintable)
-  
+      state.updateChild(
+        state.paintable, widget.valPaintable, adw_status_page_set_paintable
+      )
+
   hooks title:
     property:
       adw_status_page_set_title(state.internalWidget, state.title.cstring)
-  
+
   hooks description:
     property:
       adw_status_page_set_description(state.internalWidget, state.description.cstring)
-  
+
   hooks child:
     (build, update):
       state.updateChild(state.child, widget.valChild, adw_status_page_set_child)
-  
+
   adder add:
     if widget.hasChild:
       raise newException(ValueError, "Unable to add multiple children to a StatusPage.")
     widget.hasChild = true
     widget.valChild = child
-    
+
   adder addPaintable:
     if widget.hasPaintable:
-      raise newException(ValueError, "Unable to add multiple paintables to a StatusPage.")
+      raise
+        newException(ValueError, "Unable to add multiple paintables to a StatusPage.")
     widget.hasPaintable = true
     widget.valPaintable = child
 
 renderable ToolbarView {.since: AdwVersion >= (1, 4).} of BaseWidget:
-  content: Widget
-  bottomBars: seq[Widget]
-  topBars: seq[Widget]
-  bottomBarStyle: ToolbarStyle = ToolbarFlat
-  extendContentToBottomEdge: bool = false
-  extendContentToTopEdge: bool = false
-  revealBottomBars: bool = true
-  revealTopBars: bool = true
-  topBarStyle: ToolbarStyle = ToolbarFlat
-  
+  content:
+    Widget
+  bottomBars:
+    seq[Widget]
+  topBars:
+    seq[Widget]
+  bottomBarStyle:
+    ToolbarStyle = ToolbarFlat
+  extendContentToBottomEdge:
+    bool = false
+  extendContentToTopEdge:
+    bool = false
+  revealBottomBars:
+    bool = true
+  revealTopBars:
+    bool = true
+  topBarStyle:
+    ToolbarStyle = ToolbarFlat
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_toolbar_view_new()
-  
+
   hooks content:
     (build, update):
-      state.updateChild(
-        state.content,
-        widget.valContent,
-        adw_toolbar_view_set_content
-      )
-  
+      state.updateChild(state.content, widget.valContent, adw_toolbar_view_set_content)
+
   hooks bottomBars:
     (build, update):
       state.updateChildren(
-        state.bottomBars,
-        widget.valBottomBars,
-        adw_toolbar_view_add_bottom_bar,
-        adw_toolbar_view_remove
+        state.bottomBars, widget.valBottomBars, adw_toolbar_view_add_bottom_bar,
+        adw_toolbar_view_remove,
       )
-  
+
   hooks topBars:
     (build, update):
       state.updateChildren(
-        state.topBars,
-        widget.valTopBars,
-        adw_toolbar_view_add_top_bar,
-        adw_toolbar_view_remove
+        state.topBars, widget.valTopBars, adw_toolbar_view_add_top_bar,
+        adw_toolbar_view_remove,
       )
-    
+
   hooks bottomBarStyle:
     property:
       adw_toolbar_view_set_bottom_bar_style(state.internalWidget, state.bottomBarStyle)
-  
+
   hooks extendContentToBottomEdge:
     property:
-      adw_toolbar_view_set_extend_content_to_bottom_edge(state.internalWidget, state.extendContentToBottomEdge.cbool)
-  
+      adw_toolbar_view_set_extend_content_to_bottom_edge(
+        state.internalWidget, state.extendContentToBottomEdge.cbool
+      )
+
   hooks extendContentToTopEdge:
     property:
-      adw_toolbar_view_set_extend_content_to_top_edge(state.internalWidget, state.extendContentToTopEdge.cbool)
-  
+      adw_toolbar_view_set_extend_content_to_top_edge(
+        state.internalWidget, state.extendContentToTopEdge.cbool
+      )
+
   hooks revealBottomBars:
     property:
-      adw_toolbar_view_set_reveal_bottom_bars(state.internalWidget, state.revealBottomBars.cbool)
-      
+      adw_toolbar_view_set_reveal_bottom_bars(
+        state.internalWidget, state.revealBottomBars.cbool
+      )
+
   hooks revealTopBars:
     property:
-      adw_toolbar_view_set_reveal_top_bars(state.internalWidget, state.revealTopBars.cbool)
-      
+      adw_toolbar_view_set_reveal_top_bars(
+        state.internalWidget, state.revealTopBars.cbool
+      )
+
   hooks topBarStyle:
     property:
       adw_toolbar_view_set_top_bar_style(state.internalWidget, state.topBarStyle)
-  
+
   adder add:
     if widget.hasContent:
-      raise newException(ValueError, "Unable to add multiple children to a ToolbarView. Use a Box widget to display multiple widgets!")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a ToolbarView. Use a Box widget to display multiple widgets!",
+      )
     widget.hasContent = true
     widget.valContent = child
-  
+
   adder addBottom:
     widget.hasBottomBars = true
     widget.valBottomBars.add(child)
-  
+
   adder addTop:
     widget.hasTopBars = true
     widget.valTopBars.add(child)
@@ -1117,39 +1276,70 @@ type LegalSection* = object
   license*: Option[string]
 
 renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
-  applicationName: string
-  developerName: string
-  version: string
-  supportUrl: string
-  issueUrl: string
-  website: string
-  copyright: string
-  license: string ## A custom license text. If this field is used instead of `licenseType`, `licenseType` has to be empty or `LicenseCustom`.
-  licenseType: LicenseType ## A license from the `LicenseType` enum.
-  legalSections: seq[LegalSection] ## Adds extra sections to the "Legal" page. You can use these sections for dependency package attributions etc.
-  applicationIcon: string
-  releaseNotes: string
-  comments: string
-  debugInfo: string ## Adds a "Troubleshooting" section. Use this field to provide instructions on how to acquire logs or other info you want users of your app to know about when reporting bugs or debugging.
-  developers: seq[string]
-  designers: seq[string]
-  artists: seq[string]
-  documenters: seq[string]
-  credits: seq[tuple[title: string, people: seq[string]]] ## Additional credit sections with customizable titles
-  acknowledgements: seq[tuple[title: string, people: seq[string]]] ## Acknowledgment sections with customizable titles
-  links: seq[tuple[title: string, url: string]] ## Additional links placed in the details section
-  
+  applicationName:
+    string
+  developerName:
+    string
+  version:
+    string
+  supportUrl:
+    string
+  issueUrl:
+    string
+  website:
+    string
+  copyright:
+    string
+  license:
+    string
+    ## A custom license text. If this field is used instead of `licenseType`, `licenseType` has to be empty or `LicenseCustom`.
+  licenseType:
+    LicenseType ## A license from the `LicenseType` enum.
+  legalSections:
+    seq[LegalSection]
+    ## Adds extra sections to the "Legal" page. You can use these sections for dependency package attributions etc.
+  applicationIcon:
+    string
+  releaseNotes:
+    string
+  comments:
+    string
+  debugInfo:
+    string
+    ## Adds a "Troubleshooting" section. Use this field to provide instructions on how to acquire logs or other info you want users of your app to know about when reporting bugs or debugging.
+  developers:
+    seq[string]
+  designers:
+    seq[string]
+  artists:
+    seq[string]
+  documenters:
+    seq[string]
+  credits:
+    seq[tuple[title: string, people: seq[string]]]
+    ## Additional credit sections with customizable titles
+  acknowledgements:
+    seq[tuple[title: string, people: seq[string]]]
+    ## Acknowledgment sections with customizable titles
+  links:
+    seq[tuple[title: string, url: string]]
+    ## Additional links placed in the details section
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_about_window_new()
-  
+
   hooks applicationName:
     property:
-      adw_about_window_set_application_name(state.internalWidget, state.applicationName.cstring)
+      adw_about_window_set_application_name(
+        state.internalWidget, state.applicationName.cstring
+      )
 
   hooks developerName:
     property:
-      adw_about_window_set_developer_name(state.internalWidget, state.developerName.cstring)
+      adw_about_window_set_developer_name(
+        state.internalWidget, state.developerName.cstring
+      )
 
   hooks version:
     property:
@@ -1162,7 +1352,7 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
   hooks issueUrl:
     property:
       adw_about_window_set_issue_url(state.internalWidget, state.issueUrl.cstring)
-  
+
   hooks website:
     property:
       adw_about_window_set_website(state.internalWidget, state.website.cstring)
@@ -1196,16 +1386,20 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
             section.title,
             copyright,
             section.licenseType.toGtk(),
-            license
+            license,
           )
 
   hooks applicationIcon:
     property:
-      adw_about_window_set_application_icon(state.internalWidget, state.applicationIcon.cstring)
+      adw_about_window_set_application_icon(
+        state.internalWidget, state.applicationIcon.cstring
+      )
 
   hooks releaseNotes:
     property:
-      adw_about_window_set_release_notes(state.internalWidget, state.releaseNotes.cstring)
+      adw_about_window_set_release_notes(
+        state.internalWidget, state.releaseNotes.cstring
+      )
 
   hooks comments:
     property:
@@ -1218,25 +1412,29 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
   hooks developers:
     property:
       let developers = allocCStringArray(state.developers)
-      defer: deallocCStringArray(developers)
+      defer:
+        deallocCStringArray(developers)
       adw_about_window_set_developers(state.internalWidget, developers)
 
   hooks designers:
     property:
       let designers = allocCStringArray(state.designers)
-      defer: deallocCStringArray(designers)
+      defer:
+        deallocCStringArray(designers)
       adw_about_window_set_designers(state.internalWidget, designers)
 
   hooks artists:
     property:
       let artists = allocCStringArray(state.artists)
-      defer: deallocCStringArray(artists)
+      defer:
+        deallocCStringArray(artists)
       adw_about_window_set_artists(state.internalWidget, artists)
 
   hooks documenters:
     property:
       let documenters = allocCStringArray(state.documenters)
-      defer: deallocCStringArray(documenters)
+      defer:
+        deallocCStringArray(documenters)
       adw_about_window_set_documenters(state.internalWidget, documenters)
 
   hooks credits:
@@ -1245,8 +1443,11 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
         state.credits = widget.valCredits
         for (title, people) in state.credits:
           let names = allocCStringArray(people)
-          defer: deallocCStringArray(names)
-          adw_about_window_add_credit_section(state.internalWidget, title.cstring, names)
+          defer:
+            deallocCStringArray(names)
+          adw_about_window_add_credit_section(
+            state.internalWidget, title.cstring, names
+          )
 
   hooks acknowledgements:
     build:
@@ -1254,8 +1455,11 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
         state.acknowledgements = widget.valAcknowledgements
         for (title, people) in state.acknowledgements:
           let names = allocCStringArray(people)
-          defer: deallocCStringArray(names)
-          adw_about_window_add_acknowledgement_section(state.internalWidget, title.cstring, names)
+          defer:
+            deallocCStringArray(names)
+          adw_about_window_add_acknowledgement_section(
+            state.internalWidget, title.cstring, names
+          )
 
   hooks links:
     build:
@@ -1273,11 +1477,14 @@ renderable AboutWindow {.since: AdwVersion >= (1, 2).}:
       supportUrl = "https://github.com/can-lehmann/owlkettle/discussions"
       issueUrl = "https://github.com/can-lehmann/owlkettle/issues"
       website = "https://can-lehmann.github.io/owlkettle/README"
-      links = @{
-        "Tutorial": "https://can-lehmann.github.io/owlkettle/docs/tutorial.html",
-        "Installation": "https://can-lehmann.github.io/owlkettle/docs/installation.html",
-      }
-      comments = """My Application demonstrates the use of the Adwaita AboutWindow. Comments will be shown on the Details page, above links. <i>Unlike</i> GtkAboutDialog comments, this string can be long and detailed. It can also contain <a href='https://docs.gtk.org/Pango/pango_markup.html'>links</a> and <b>Pango markup</b>."""
+      links =
+        @{
+          "Tutorial": "https://can-lehmann.github.io/owlkettle/docs/tutorial.html",
+          "Installation":
+            "https://can-lehmann.github.io/owlkettle/docs/installation.html",
+        }
+      comments =
+        """My Application demonstrates the use of the Adwaita AboutWindow. Comments will be shown on the Details page, above links. <i>Unlike</i> GtkAboutDialog comments, this string can be long and detailed. It can also contain <a href='https://docs.gtk.org/Pango/pango_markup.html'>links</a> and <b>Pango markup</b>."""
       copyright = "Erika Mustermann"
       licenseType = LicenseMIT_X11
 
@@ -1292,33 +1499,33 @@ type Toast* = ref object
   useMarkup*: bool
 
 proc newToast*(
-  title: string,
-  buttonLabel: string = "", 
-  priority: ToastPriority = ToastPriorityNormal, 
-  dismissalHandler: proc() = nil, 
-  clickedHandler: proc() = nil,
-  timeout: int = 5,
-  useMarkup: bool = false,
-  customTitle: Widget = nil.Widget
+    title: string,
+    buttonLabel: string = "",
+    priority: ToastPriority = ToastPriorityNormal,
+    dismissalHandler: proc() = nil,
+    clickedHandler: proc() = nil,
+    timeout: int = 5,
+    useMarkup: bool = false,
+    customTitle: Widget = nil.Widget,
 ): Toast =
   result = Toast(
-    title: title, 
+    title: title,
     buttonLabel: buttonLabel,
     priority: priority,
     timeout: timeout,
     dismissalHandler: dismissalHandler,
     clickedHandler: clickedHandler,
     customTitle: customTitle,
-    useMarkup: useMarkup
+    useMarkup: useMarkup,
   )
 
 proc connectSignal(obj: pointer, userCallback: proc() {.closure.}, eventName: string) =
-  proc callback(obj: pointer, data: ptr EventObj[proc ()]) {.cdecl.} = 
+  proc callback(obj: pointer, data: ptr EventObj[proc()]) {.cdecl.} =
     let event = unwrapSharedCell(data)
     event.callback()
     # Disconnect event-handler after Toast was dismissed
     g_signal_handler_disconnect(obj, event.handler)
-  
+
   let event = EventObj[proc()]()
   let data = allocSharedCell(event)
   data.callback = userCallback
@@ -1330,11 +1537,11 @@ proc toGtk(toast: Toast): AdwToast =
     adw_toast_set_button_label(result, toast.buttonLabel.cstring)
   adw_toast_set_priority(result, toast.priority)
   adw_toast_set_timeout(result, toast.timeout.cuint)
-  
+
   # Set Dismissal Handler
   if not toast.dismissalHandler.isNil():
     connectSignal(pointer(result), toast.dismissalHandler, "dismissed")
-  
+
   when AdwVersion >= (1, 2):
     if not toast.customTitle.isNil():
       let customTitleWidget = toast.customTitle.build().unwrapInternalWidget()
@@ -1346,30 +1553,42 @@ proc toGtk(toast: Toast): AdwToast =
   else:
     let isUsingCustomTitle = not toast.customTitle.isNil()
     if isUsingCustomTitle:
-      raise newException(LibraryError, "The customTitle field on a Toast instance is not available when compiling for Adwaita versions below 1.2. Compile for Adwaita version 1.2 or higher with -d:adwminor=2 to enable it")
+      raise newException(
+        LibraryError,
+        "The customTitle field on a Toast instance is not available when compiling for Adwaita versions below 1.2. Compile for Adwaita version 1.2 or higher with -d:adwminor=2 to enable it",
+      )
 
     let isUsingClickedHandler = not toast.clickedHandler.isNil()
     if isUsingClickedHandler:
-      raise newException(LibraryError, "The clickedHandler field on a Toast instance is not available when compiling for Adwaita versions below 1.2. Compile for Adwaita version 1.2 or higher with -d:adwminor=2 to enable it")
+      raise newException(
+        LibraryError,
+        "The clickedHandler field on a Toast instance is not available when compiling for Adwaita versions below 1.2. Compile for Adwaita version 1.2 or higher with -d:adwminor=2 to enable it",
+      )
 
   when AdwVersion >= (1, 4):
     adw_toast_set_use_markup(result, toast.useMarkup.cbool)
   else:
     if toast.useMarkup:
-      raise newException(LibraryError, "The useMarkup field on a Toast instance is not available when compiling for Adwaita versions below 1.4. Compile for Adwaita version 1.4 or higher with -d:adwminor=4 to enable it")
+      raise newException(
+        LibraryError,
+        "The useMarkup field on a Toast instance is not available when compiling for Adwaita versions below 1.4. Compile for Adwaita version 1.4 or higher with -d:adwminor=4 to enable it",
+      )
 
 type ToastQueue* = ref object
   toasts: seq[Toast]
 
-proc newToastQueue*(): ToastQueue = ToastQueue()
-proc add*(queue: ToastQueue, toast: Toast) = 
+proc newToastQueue*(): ToastQueue =
+  ToastQueue()
+
+proc add*(queue: ToastQueue, toast: Toast) =
   queue.toasts.add(toast)
-    
+
 proc add*(queue: ToastQueue, toasts: openArray[Toast]) =
   for toast in toasts:
     queue.add(toast)
 
-proc clear(queue: ToastQueue) = queue.toasts = @[]
+proc clear(queue: ToastQueue) =
+  queue.toasts = @[]
 
 renderable ToastOverlay of BaseWidget:
   ## Displays messages (toasts) to the user.
@@ -1386,17 +1605,20 @@ renderable ToastOverlay of BaseWidget:
   ## - clickedHandler: An event handler which is called when the user clicks on the button that appears if `buttonLabel` is defined. Only available when compiling for Adwaita version 1.2 or higher.
   ## - useMarkup: Whether to interpret the title as Pango Markup. Only available when compiling for Adwaita version 1.4 or higher.
 
-  child: Widget
-  toastQueue: ToastQueue ## The Toasts to display. Toasts of priority `ToastPriorityNormal` are displayed in First-In-First-Out order, after toasts of priority `ToastPriorityHigh` which are displayed in Last-In-First-Out order.
+  child:
+    Widget
+  toastQueue:
+    ToastQueue
+    ## The Toasts to display. Toasts of priority `ToastPriorityNormal` are displayed in First-In-First-Out order, after toasts of priority `ToastPriorityHigh` which are displayed in Last-In-First-Out order.
 
   hooks:
     beforeBuild:
       state.internalWidget = adw_toast_overlay_new()
-  
+
   hooks child:
     (build, update):
       state.updateChild(state.child, widget.valChild, adw_toast_overlay_set_child)
-  
+
   hooks toastQueue:
     (build, update):
       state.toastQueue = widget.valToastQueue
@@ -1404,46 +1626,57 @@ renderable ToastOverlay of BaseWidget:
         for toast in state.toastQueue.toasts:
           adw_toast_overlay_add_toast(state.internalWidget, toast.toGtk())
         state.toastQueue.clear()
-  
+
   adder add:
     if widget.hasChild:
-      raise newException(ValueError, "Unable to add multiple children to a ToastOverlay. Use a Box widget to display multiple widgets in a ToastOverlay.")
+      raise newException(
+        ValueError,
+        "Unable to add multiple children to a ToastOverlay. Use a Box widget to display multiple widgets in a ToastOverlay.",
+      )
     widget.hasChild = true
     widget.valChild = child
 
 renderable SwitchRow {.since: AdwVersion >= (1, 4).} of ActionRow:
-  active: bool
-  
+  active:
+    bool
+
   proc activated(active: bool)
-  
+
   hooks:
     beforeBuild:
-        state.internalWidget = adw_switch_row_new()
+      state.internalWidget = adw_switch_row_new()
     connectEvents:
-      proc activatedCallback(widget: GtkWidget, data: ptr EventObj[proc (active: bool)]) {.cdecl.} =
+      proc activatedCallback(
+          widget: GtkWidget, data: ptr EventObj[proc(active: bool)]
+      ) {.cdecl.} =
         logExceptions:
           let active: bool = adw_switch_row_get_active(widget).bool
           SwitchRowState(data[].widget).active = active
           data[].callback(active)
           data[].redraw()
-        
+
       state.connect(state.activated, "activated", activatedCallback)
     disconnectEvents:
       state.internalWidget.disconnect(state.activated)
-  
+
   hooks active:
     property:
       adw_switch_row_set_active(state.internalWidget, state.active.cbool)
 
 renderable Banner {.since: AdwVersion >= (1, 3).} of BaseWidget:
   ## A rectangular Box taking up the entire vailable width with an optional button.
-  buttonLabel: string ## Label of the optional banner button. Button will only be added to the banner if this Label has a value.
-  title: string
-  useMarkup: bool = true ## Determines whether using Markup in title is allowed or not.
-  revealed: bool = true ## Determines whether the banner is shown.
-  
+  buttonLabel:
+    string
+    ## Label of the optional banner button. Button will only be added to the banner if this Label has a value.
+  title:
+    string
+  useMarkup:
+    bool = true ## Determines whether using Markup in title is allowed or not.
+  revealed:
+    bool = true ## Determines whether the banner is shown.
+
   proc clicked() ## Triggered by clicking the banner button
-  
+
   hooks:
     beforeBuild:
       state.internalWidget = adw_banner_new("".cstring)
@@ -1454,11 +1687,11 @@ renderable Banner {.since: AdwVersion >= (1, 3).} of BaseWidget:
   hooks buttonLabel:
     property:
       adw_banner_set_button_label(state.internalWidget, state.buttonLabel.cstring)
-  
+
   hooks title:
     property:
       adw_banner_set_title(state.internalWidget, state.title.cstring)
-  
+
   hooks useMarkup:
     property:
       adw_banner_set_use_markup(state.internalWidget, state.useMarkup.cbool)
@@ -1467,6 +1700,11 @@ renderable Banner {.since: AdwVersion >= (1, 3).} of BaseWidget:
     property:
       adw_banner_set_revealed(state.internalWidget, state.revealed.cbool)
 
+renderable AdwSpinner {.since: AdwVersion >= (1, 6).} of BaseWidget:
+  ## A widget showing a loading spinner.
+  hooks:
+    beforeBuild:
+      state.internalWidget = adw_spinner_new()
 
 proc defaultStyleManager*(): StyleManager =
   result = adw_style_manager_get_default()
@@ -1489,73 +1727,80 @@ type AdwAppConfig = object of AppConfig
 proc setupApp(config: AdwAppConfig): WidgetState =
   let styleManager = adw_style_manager_get_default()
   adw_style_manager_set_color_scheme(styleManager, config.colorScheme)
-  
+
   result = setupApp(AppConfig(config))
 
-proc brew*(widget: Widget,
-           icons: openArray[string] = [],
-           colorScheme: ColorScheme = ColorSchemeDefault,
-           startupEvents: openArray[ApplicationEvent] = [],
-           shutdownEvents: openArray[ApplicationEvent] = [],
-           stylesheets: openArray[Stylesheet] = []) =
+proc brew*(
+    widget: Widget,
+    icons: openArray[string] = [],
+    colorScheme: ColorScheme = ColorSchemeDefault,
+    startupEvents: openArray[ApplicationEvent] = [],
+    shutdownEvents: openArray[ApplicationEvent] = [],
+    stylesheets: openArray[Stylesheet] = [],
+) =
   adw_init()
   let config = AdwAppConfig(
     widget: widget,
     icons: @icons,
     darkTheme: false,
     colorScheme: colorScheme,
-    stylesheets: @stylesheets
+    stylesheets: @stylesheets,
   )
   let state = setupApp(config)
-  
+
   let context = AppContext[AdwAppConfig](
     config: config,
     state: state,
     startupEvents: @startupEvents,
-    shutdownEvents: @shutdownEvents
+    shutdownEvents: @shutdownEvents,
   )
-  
+
   context.execStartupEvents()
   runMainloop(state)
   context.execShutdownEvents()
 
-proc brew*(id: string,
-           widget: Widget,
-           icons: openArray[string] = [],
-           colorScheme: ColorScheme = ColorSchemeDefault,
-           startupEvents: openArray[ApplicationEvent] = [],
-           shutdownEvents: openArray[ApplicationEvent] = [],
-           stylesheets: openArray[Stylesheet] = []) =
+proc brew*(
+    id: string,
+    widget: Widget,
+    icons: openArray[string] = [],
+    colorScheme: ColorScheme = ColorSchemeDefault,
+    startupEvents: openArray[ApplicationEvent] = [],
+    shutdownEvents: openArray[ApplicationEvent] = [],
+    stylesheets: openArray[Stylesheet] = [],
+) =
   var config = AdwAppConfig(
     widget: widget,
     icons: @icons,
     darkTheme: false,
     colorScheme: colorScheme,
-    stylesheets: @stylesheets
+    stylesheets: @stylesheets,
   )
-  
+
   var context = AppContext[AdwAppConfig](
-    config: config,
-    startupEvents: @startupEvents,
-    shutdownEvents: @shutdownEvents
+    config: config, startupEvents: @startupEvents, shutdownEvents: @shutdownEvents
   )
-  
-  proc activateCallback(app: GApplication, data: ptr AppContext[AdwAppConfig]) {.cdecl.} =
+
+  proc activateCallback(
+      app: GApplication, data: ptr AppContext[AdwAppConfig]
+  ) {.cdecl.} =
     let
       state = setupApp(data[].config)
       window = state.unwrapRenderable().internalWidget
     gtk_window_present(window)
     gtk_application_add_window(app, window)
-    
+
     data[].state = state
     data[].execStartupEvents()
 
   let app = adw_application_new(id.cstring, G_APPLICATION_FLAGS_NONE)
-  defer: g_object_unref(app.pointer)
-  
-  proc shutdownCallback(app: GApplication, data: ptr AppContext[AdwAppConfig]) {.cdecl.} =
+  defer:
+    g_object_unref(app.pointer)
+
+  proc shutdownCallback(
+      app: GApplication, data: ptr AppContext[AdwAppConfig]
+  ) {.cdecl.} =
     data[].execShutdownEvents()
-  
+
   discard g_signal_connect(app, "activate", activateCallback, context.addr)
   discard g_signal_connect(app, "shutdown", shutdownCallback, context.addr)
   discard g_application_run(app)

--- a/owlkettle/bindings/adw.nim
+++ b/owlkettle/bindings/adw.nim
@@ -25,40 +25,42 @@
 import std/strutils as strutils
 import ./gtk
 
-const AdwMajor {.intdefine: "adwmajor".}: int = 1 ## Specifies the minimum Adwaita major version required to run an application. Overwriteable via `-d:adwmajor=X`. Defaults to 1.
-const AdwMinor {.intdefine: "adwminor".}: int = 0 ## Specifies the minimum Adwaita minor version required to run an application. Overwriteable via `-d:adwminor=X`. Defaults to 0.
+const AdwMajor {.intdefine: "adwmajor".}: int = 1
+  ## Specifies the minimum Adwaita major version required to run an application. Overwriteable via `-d:adwmajor=X`. Defaults to 1.
+const AdwMinor {.intdefine: "adwminor".}: int = 0
+  ## Specifies the minimum Adwaita minor version required to run an application. Overwriteable via `-d:adwminor=X`. Defaults to 0.
 const AdwVersion* = (AdwMajor, AdwMinor)
 
 {.passl: strutils.strip(gorge("pkg-config --libs libadwaita-1")).}
 
 type
   StyleManager* = distinct pointer
-  
+
   CenteringPolicy* = enum
     CenteringPolicyLoose
     CenteringPolicyStrict
-  
+
   ColorScheme* = enum
-    ColorSchemeDefault,
-    ColorSchemeForceLight,
-    ColorSchemeForceDark,
-    ColorSchemePreferDark,
+    ColorSchemeDefault
+    ColorSchemeForceLight
+    ColorSchemeForceDark
+    ColorSchemePreferDark
     ColorSchemePreferLight
-  
+
   FlapFoldPolicy* = enum
-    FlapFoldNever,
-    FlapFoldAlways,
+    FlapFoldNever
+    FlapFoldAlways
     FlapFoldAuto
-  
+
   FoldThresholdPolicy* = enum
-    FoldThresholdMinimum,
+    FoldThresholdMinimum
     FoldThresholdNatural
-  
+
   FlapTransitionType* = enum
     FlapTransitionOver
     FlapTransitionUnder
     FlapTransitionSlide
-  
+
   LengthUnit* = enum
     LengthPixel
     LengthPoint
@@ -80,7 +82,8 @@ proc isNil*(manager: StyleManager): bool {.borrow.}
 proc isNil*(widget: AdwToast): bool {.borrow.}
 
 proc g_signal_connect*(app: AdwToast, signal: cstring, closure, data: pointer): culong =
-  result = g_signal_connect_data(app.pointer, signal, closure, data, nil, G_CONNECT_AFTER)
+  result =
+    g_signal_connect_data(app.pointer, signal, closure, data, nil, G_CONNECT_AFTER)
 
 {.push importc, cdecl.}
 # Adw
@@ -91,7 +94,10 @@ proc adw_application_new*(id: cstring, flags: GApplicationFlags): GApplication
 
 # Adw.StyleManager
 proc adw_style_manager_get_default*(): StyleManager
-proc adw_style_manager_set_color_scheme*(manager: StyleManager, colorScheme: ColorScheme)
+proc adw_style_manager_set_color_scheme*(
+  manager: StyleManager, colorScheme: ColorScheme
+)
+
 proc adw_style_manager_get_color_scheme*(manager: StyleManager): ColorScheme
 proc adw_style_manager_get_dark*(manager: StyleManager): cbool
 proc adw_style_manager_get_high_contrast*(manager: StyleManager): cbool
@@ -168,7 +174,10 @@ proc adw_expander_row_add_row*(expanderRow, row: GtkWidget)
 proc adw_expander_row_remove*(row, child: GtkWidget)
 proc adw_expander_row_set_enable_expansion*(self: GtkWidget, enable_expansion: cbool)
 proc adw_expander_row_set_expanded*(self: GtkWidget, expanded: cbool)
-proc adw_expander_row_set_show_enable_switch*(self: GtkWidget, show_enable_switch: cbool)
+proc adw_expander_row_set_show_enable_switch*(
+  self: GtkWidget, show_enable_switch: cbool
+)
+
 proc adw_expander_row_get_expanded*(self: GtkWidget): cbool
 
 when AdwVersion >= (1, 3):
@@ -201,7 +210,10 @@ proc adw_flap_set_content*(flap, content: GtkWidget)
 proc adw_flap_set_flap*(flap, child: GtkWidget)
 proc adw_flap_set_separator*(flap, child: GtkWidget)
 proc adw_flap_set_fold_policy*(flap: GtkWidget, foldPolicy: FlapFoldPolicy)
-proc adw_flap_set_fold_threshold_policy*(flap: GtkWidget, foldThresholdPolicy: FoldThresholdPolicy)
+proc adw_flap_set_fold_threshold_policy*(
+  flap: GtkWidget, foldThresholdPolicy: FoldThresholdPolicy
+)
+
 proc adw_flap_set_transition_type*(flap: GtkWidget, transitionType: FlapTransitionType)
 proc adw_flap_set_reveal_flap*(flap: GtkWidget, revealed: cbool)
 proc adw_flap_set_modal*(flap: GtkWidget, modal: cbool)
@@ -217,17 +229,29 @@ when AdwVersion >= (1, 4):
   proc adw_overlay_split_view_get_show_sidebar*(self: GtkWidget): cbool
   proc adw_overlay_split_view_set_collapsed*(self: GtkWidget, collapsed: cbool)
   proc adw_overlay_split_view_set_content*(self, content: GtkWidget)
-  proc adw_overlay_split_view_set_enable_hide_gesture*(self: GtkWidget, enable_hide_gesture: cbool)
-  proc adw_overlay_split_view_set_enable_show_gesture*(self: GtkWidget, enable_show_gesture: cbool)
+  proc adw_overlay_split_view_set_enable_hide_gesture*(
+    self: GtkWidget, enable_hide_gesture: cbool
+  )
+
+  proc adw_overlay_split_view_set_enable_show_gesture*(
+    self: GtkWidget, enable_show_gesture: cbool
+  )
+
   proc adw_overlay_split_view_set_max_sidebar_width*(self: GtkWidget, width: cdouble)
   proc adw_overlay_split_view_set_min_sidebar_width*(self: GtkWidget, width: cdouble)
   proc adw_overlay_split_view_set_pin_sidebar*(self: GtkWidget, pin_sidebar: cbool)
   proc adw_overlay_split_view_set_show_sidebar*(self: GtkWidget, show_sidebar: cbool)
   proc adw_overlay_split_view_set_sidebar*(self, sidebar: GtkWidget)
-  proc adw_overlay_split_view_set_sidebar_position*(self: GtkWidget, position: GtkPackType)
-  proc adw_overlay_split_view_set_sidebar_width_fraction*(self: GtkWidget, fraction: cdouble)
+  proc adw_overlay_split_view_set_sidebar_position*(
+    self: GtkWidget, position: GtkPackType
+  )
+
+  proc adw_overlay_split_view_set_sidebar_width_fraction*(
+    self: GtkWidget, fraction: cdouble
+  )
+
   proc adw_overlay_split_view_set_sidebar_width_unit*(self: GtkWidget, unit: LengthUnit)
-  
+
 # Adw.SplitButton
 proc adw_split_button_new*(): GtkWidget
 proc adw_split_button_set_child*(button, child: GtkWidget)
@@ -248,7 +272,10 @@ when AdwVersion >= (1, 4):
   proc adw_toolbar_view_remove*(self, widget: GtkWidget)
   proc adw_toolbar_view_set_bottom_bar_style*(self: GtkWidget, style: ToolbarStyle)
   proc adw_toolbar_view_set_content*(self, content: GtkWidget)
-  proc adw_toolbar_view_set_extend_content_to_bottom_edge*(self: GtkWidget, extend: cbool)
+  proc adw_toolbar_view_set_extend_content_to_bottom_edge*(
+    self: GtkWidget, extend: cbool
+  )
+
   proc adw_toolbar_view_set_extend_content_to_top_edge*(self: GtkWidget, extend: cbool)
   proc adw_toolbar_view_set_reveal_bottom_bars*(self: GtkWidget, reveal: cbool)
   proc adw_toolbar_view_set_reveal_top_bars*(self: GtkWidget, reveal: cbool)
@@ -259,7 +286,10 @@ proc adw_header_bar_new*(): GtkWidget
 proc adw_header_bar_pack_end*(self, child: GtkWidget)
 proc adw_header_bar_pack_start*(self, child: GtkWidget)
 proc adw_header_bar_remove*(self, child: GtkWidget)
-proc adw_header_bar_set_centering_policy*(self: GtkWidget, centering_policy: CenteringPolicy)
+proc adw_header_bar_set_centering_policy*(
+  self: GtkWidget, centering_policy: CenteringPolicy
+)
+
 proc adw_header_bar_set_decoration_layout*(self: GtkWidget, layout: cstring)
 proc adw_header_bar_set_show_end_title_buttons*(self: GtkWidget, setting: cbool)
 proc adw_header_bar_set_show_start_title_buttons*(self: GtkWidget, setting: cbool)
@@ -281,7 +311,14 @@ when AdwVersion >= (1, 2):
   proc adw_about_window_set_copyright*(window: GtkWidget, value: cstring)
   proc adw_about_window_set_license*(window: GtkWidget, value: cstring)
   proc adw_about_window_set_license_type*(window: GtkWidget, value: GtkLicenseType)
-  proc adw_about_window_add_legal_section*(window: GtkWidget, title: cstring, copyright: cstring, license_type: GtkLicenseType, license: cstring)
+  proc adw_about_window_add_legal_section*(
+    window: GtkWidget,
+    title: cstring,
+    copyright: cstring,
+    license_type: GtkLicenseType,
+    license: cstring,
+  )
+
   proc adw_about_window_set_application_icon*(window: GtkWidget, value: cstring)
   proc adw_about_window_set_release_notes*(window: GtkWidget, value: cstring)
   proc adw_about_window_set_comments*(window: GtkWidget, value: cstring)
@@ -290,8 +327,14 @@ when AdwVersion >= (1, 2):
   proc adw_about_window_set_designers*(window: GtkWidget, value: cstringArray)
   proc adw_about_window_set_artists*(window: GtkWidget, value: cstringArray)
   proc adw_about_window_set_documenters*(window: GtkWidget, value: cstringArray)
-  proc adw_about_window_add_credit_section*(window: GtkWidget, name: cstring, people: cstringArray)
-  proc adw_about_window_add_acknowledgement_section*(window: GtkWidget, name: cstring, people: cstringArray)
+  proc adw_about_window_add_credit_section*(
+    window: GtkWidget, name: cstring, people: cstringArray
+  )
+
+  proc adw_about_window_add_acknowledgement_section*(
+    window: GtkWidget, name: cstring, people: cstringArray
+  )
+
   proc adw_about_window_add_link*(window: GtkWidget, title: cstring, url: cstring)
 
 # Adw.ToastOverlay
@@ -337,3 +380,7 @@ when AdwVersion >= (1, 3):
   proc adw_banner_set_title*(self: GtkWidget, title: cstring)
   proc adw_banner_set_use_markup*(self: GtkWidget, use_markup: cbool)
   proc adw_banner_set_revealed*(self: GtkWidget, revealed: cbool)
+
+when AdwVersion >= (1, 6):
+  # Adw.Spinner
+  proc adw_spinner_new*(): GtkWidget

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+with import <nixpkgs> { };
+
+mkShell {
+  nativeBuildInputs = [
+    pkg-config
+    gtk4
+    libadwaita
+  ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    gtk4.dev
+    libadwaita.dev
+  ];
+}


### PR DESCRIPTION
- **add: nix: create nix shell**
- **add: implement `Adw.Spinner` widget**

These new libadwaita spinner widgets are nicer looking than the old, clunky GTK ones and they scale properly too.

(Please ignore the massive diff, nph decided it would be funny to autoformat `adw.nim`)
